### PR TITLE
Create patch files for cfx chromium changes

### DIFF
--- a/CHROMIUM_BUILD_COMPATIBILITY.txt
+++ b/CHROMIUM_BUILD_COMPATIBILITY.txt
@@ -7,6 +7,6 @@
 # https://bitbucket.org/chromiumembedded/cef/wiki/BranchesAndBuilding
 
 {
-  'chromium_checkout': 'refs/tags/103.0.5060.53',
-  'depot_tools_checkout': '964f8124b6'
+  'chromium_checkout': 'refs/tags/103.0.5060.134',
+  'depot_tools_checkout': '6d0c235dae'
 }

--- a/include/cef_api_hash.h
+++ b/include/cef_api_hash.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Marshall A. Greenblatt. All rights reserved.
+// Copyright (c) 2024 Marshall A. Greenblatt. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are

--- a/patch/patch.cfg
+++ b/patch/patch.cfg
@@ -587,7 +587,39 @@ patches = [
     'name': 'libwebp_cve',
   },
   {
-    # libvpx: This patches libvpx due to CVE-2023-5217
-    'name': 'libvpx_cve',
+    # For Arkose FunCaptcha compatibility
+    'name': 'sec_headers',
+  },
+  {
+    # Needed for FxDK
+    'name': 'path_getter',
+  },
+  {
+    # Cherry picked change from next chromium version
+    'name': 'media_access_handler',
+  },
+  {
+    # Windows 7 compatibility
+    'name': 'osr_nthandle',
+  },
+  {
+    # for CfxUI backdrop blur
+    'name': 'revert_background',
+  },
+  {
+    # for CfxUI backdrop blur
+    'name': 'revert_geometry',
+  },
+  {
+    # Cherry picked change from next chromium version
+    'name': 'cherry_paintimage',
+  },
+  {
+    # Cherry picked change from next chromium version
+    'name': 'cherry_background',
+  },
+  {
+    # NUI resource url compatibility
+    'name': 'revert_url',
   }
 ]

--- a/patch/patches/cherry_background.patch
+++ b/patch/patches/cherry_background.patch
@@ -1,0 +1,164 @@
+diff --git third_party/blink/renderer/core/paint/box_painter_base.cc third_party/blink/renderer/core/paint/box_painter_base.cc
+index 0b80634f3e2e2..7b29e749c536e 100644
+--- third_party/blink/renderer/core/paint/box_painter_base.cc
++++ third_party/blink/renderer/core/paint/box_painter_base.cc
+@@ -764,11 +764,26 @@ inline bool PaintFastBottomLayer(const Document* document,
+ 
+   auto image_auto_dark_mode = ImageClassifierHelper::GetImageAutoDarkMode(
+       *document->GetFrame(), style, image_border.Rect(), src_rect);
++
++  Image::ImageClampingMode clamping_mode =
++      Image::ImageClampingMode::kClampImageToSourceRect;
++
++  // If the intended snapped background image is the whole tile, do not clamp
++  // the source rect. This allows mipmaps and filtering to read beyond the
++  // final adjusted source rect even if snapping and scaling means it's subset.
++  // However, this detects and preserves clamping to the source rect for sprite
++  // sheet background images.
++  if (geometry.TileSize().width == geometry.SnappedDestRect().Width() &&
++      geometry.TileSize().height == geometry.SnappedDestRect().Height()) {
++    clamping_mode = Image::ImageClampingMode::kDoNotClampImageToSourceRect;
++  }
++
+   // Since there is no way for the developer to specify decode behavior, use
+   // kSync by default.
+   context.DrawImageRRect(image, Image::kSyncDecode, image_auto_dark_mode,
+                          image_border, src_rect, composite_op,
+-                         info.respect_image_orientation, may_be_lcp_candidate);
++                         info.respect_image_orientation, may_be_lcp_candidate,
++                         clamping_mode);
+ 
+   return true;
+ }
+diff --git third_party/blink/renderer/core/paint/box_painter_test.cc third_party/blink/renderer/core/paint/box_painter_test.cc
+index ec8190d49ab4b..b7e03ce10c341 100644
+--- third_party/blink/renderer/core/paint/box_painter_test.cc
++++ third_party/blink/renderer/core/paint/box_painter_test.cc
+@@ -277,4 +277,41 @@ TEST_P(BoxPainterTest, ScrollerUnderInlineTransform3DSceneLeafCrash) {
+   // This should not crash.
+ }
+ 
++size_t CountDrawImagesWithConstraint(const cc::PaintOpBuffer* buffer,
++                                     SkCanvas::SrcRectConstraint constraint) {
++  size_t count = 0;
++  for (cc::PaintOpBuffer::Iterator it(buffer); it; ++it) {
++    if (it->GetType() == cc::PaintOpType::DrawImageRect) {
++      auto* image_op = static_cast<cc::DrawImageRectOp*>(*it);
++      if (image_op->constraint == constraint)
++        ++count;
++    } else if (it->GetType() == cc::PaintOpType::DrawRecord) {
++      auto* record_op = static_cast<cc::DrawRecordOp*>(*it);
++      count +=
++          CountDrawImagesWithConstraint(record_op->record.get(), constraint);
++    }
++  }
++  return count;
++}
++
++TEST_P(BoxPainterTest, ImageClampingMode) {
++  SetBodyInnerHTML(R"HTML(
++    <!doctype html>
++    <style>
++      div#test {
++        height: 500px;
++        width: 353.743px;
++        background-image: url("data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==");
++        background-size: contain;
++        background-repeat: no-repeat;
++      }
++    </style>
++    <div id="test"></div>
++  )HTML");
++
++  sk_sp<PaintRecord> record = GetDocument().View()->GetPaintRecord();
++  EXPECT_EQ(1U, CountDrawImagesWithConstraint(
++                    record.get(), SkCanvas::kFast_SrcRectConstraint));
++}
++
+ }  // namespace blink
+diff --git third_party/blink/renderer/platform/graphics/graphics_context.cc third_party/blink/renderer/platform/graphics/graphics_context.cc
+index 8f967d93907a8..1e1b099b39e3e 100644
+--- third_party/blink/renderer/platform/graphics/graphics_context.cc
++++ third_party/blink/renderer/platform/graphics/graphics_context.cc
+@@ -752,7 +752,8 @@ void GraphicsContext::DrawImage(
+     const gfx::RectF* src_ptr,
+     SkBlendMode op,
+     RespectImageOrientationEnum should_respect_image_orientation,
+-    bool image_may_be_lcp_candidate) {
++    bool image_may_be_lcp_candidate,
++    Image::ImageClampingMode clamping_mode) {
+   if (!image)
+     return;
+ 
+@@ -763,10 +764,10 @@ void GraphicsContext::DrawImage(
+ 
+   SkSamplingOptions sampling = ComputeSamplingOptions(image, dest, src);
+   DarkModeFilter* dark_mode_filter = GetDarkModeFilterForImage(auto_dark_mode);
+-  ImageDrawOptions draw_options(
+-      dark_mode_filter, sampling, should_respect_image_orientation,
+-      Image::kClampImageToSourceRect, decode_mode, auto_dark_mode.enabled,
+-      image_may_be_lcp_candidate);
++  ImageDrawOptions draw_options(dark_mode_filter, sampling,
++                                should_respect_image_orientation, clamping_mode,
++                                decode_mode, auto_dark_mode.enabled,
++                                image_may_be_lcp_candidate);
+ 
+   image->Draw(canvas_, image_flags, dest, src, draw_options);
+   paint_controller_.SetImagePainted();
+@@ -780,13 +781,14 @@ void GraphicsContext::DrawImageRRect(
+     const gfx::RectF& src_rect,
+     SkBlendMode op,
+     RespectImageOrientationEnum respect_orientation,
+-    bool image_may_be_lcp_candidate) {
++    bool image_may_be_lcp_candidate,
++    Image::ImageClampingMode clamping_mode) {
+   if (!image)
+     return;
+ 
+   if (!dest.IsRounded()) {
+     DrawImage(image, decode_mode, auto_dark_mode, dest.Rect(), &src_rect, op,
+-              respect_orientation, image_may_be_lcp_candidate);
++              respect_orientation, image_may_be_lcp_candidate, clamping_mode);
+     return;
+   }
+ 
+@@ -804,10 +806,9 @@ void GraphicsContext::DrawImageRRect(
+   image_flags.setColor(SK_ColorBLACK);
+ 
+   DarkModeFilter* dark_mode_filter = GetDarkModeFilterForImage(auto_dark_mode);
+-  ImageDrawOptions draw_options(dark_mode_filter, sampling, respect_orientation,
+-                                Image::kClampImageToSourceRect, decode_mode,
+-                                auto_dark_mode.enabled,
+-                                image_may_be_lcp_candidate);
++  ImageDrawOptions draw_options(
++      dark_mode_filter, sampling, respect_orientation, clamping_mode,
++      decode_mode, auto_dark_mode.enabled, image_may_be_lcp_candidate);
+ 
+   bool use_shader = (visible_src == src_rect) &&
+                     (respect_orientation == kDoNotRespectImageOrientation ||
+diff --git third_party/blink/renderer/platform/graphics/graphics_context.h third_party/blink/renderer/platform/graphics/graphics_context.h
+index 329f05d66f068..064cfadadc194 100644
+--- third_party/blink/renderer/platform/graphics/graphics_context.h
++++ third_party/blink/renderer/platform/graphics/graphics_context.h
+@@ -323,7 +323,9 @@ class PLATFORM_EXPORT GraphicsContext {
+                  const gfx::RectF* src_rect = nullptr,
+                  SkBlendMode = SkBlendMode::kSrcOver,
+                  RespectImageOrientationEnum = kRespectImageOrientation,
+-                 bool image_may_be_lcp_candidate = false);
++                 bool image_may_be_lcp_candidate = false,
++                 Image::ImageClampingMode clamping_mode =
++                     Image::ImageClampingMode::kClampImageToSourceRect);
+   void DrawImageRRect(Image*,
+                       Image::ImageDecodingMode,
+                       const ImageAutoDarkMode& auto_dark_mode,
+@@ -331,7 +333,9 @@ class PLATFORM_EXPORT GraphicsContext {
+                       const gfx::RectF& src_rect,
+                       SkBlendMode = SkBlendMode::kSrcOver,
+                       RespectImageOrientationEnum = kRespectImageOrientation,
+-                      bool image_may_be_lcp_candidate = false);
++                      bool image_may_be_lcp_candidate = false,
++                      Image::ImageClampingMode clamping_mode =
++                          Image::ImageClampingMode::kClampImageToSourceRect);
+   void DrawImageTiled(Image* image,
+                       const gfx::RectF& dest_rect,
+                       const ImageTilingInfo& tiling_info,

--- a/patch/patches/cherry_paintimage.patch
+++ b/patch/patches/cherry_paintimage.patch
@@ -1,0 +1,637 @@
+diff --git cc/paint/paint_image.cc cc/paint/paint_image.cc
+index ed3a8f512146c..d8a27e33c6c10 100644
+--- cc/paint/paint_image.cc
++++ cc/paint/paint_image.cc
+@@ -71,6 +71,8 @@ bool PaintImage::operator==(const PaintImage& other) const {
+     return false;
+   if (paint_worklet_input_ != other.paint_worklet_input_)
+     return false;
++  // Do not check may_be_lcp_candidate_ as it should not affect any rendering
++  // operation, only metrics collection.
+   return true;
+ }
+ 
+@@ -397,6 +399,7 @@ std::string PaintImage::ToString() const {
+       << " animation_type_: " << static_cast<int>(animation_type_)
+       << " completion_state_: " << static_cast<int>(completion_state_)
+       << " is_multipart_: " << is_multipart_
++      << " may_be_lcp_candidate_: " << may_be_lcp_candidate_
+       << " is YUV: " << IsYuv(SkYUVAPixmapInfo::SupportedDataTypes::All());
+   return str.str();
+ }
+diff --git cc/paint/paint_image.h cc/paint/paint_image.h
+index 32cbb7fdaeb38..859f4487dc8db 100644
+--- cc/paint/paint_image.h
++++ cc/paint/paint_image.h
+@@ -264,6 +264,7 @@ class CC_PAINT_EXPORT PaintImage {
+   CompletionState completion_state() const { return completion_state_; }
+   bool is_multipart() const { return is_multipart_; }
+   bool is_high_bit_depth() const { return is_high_bit_depth_; }
++  bool may_be_lcp_candidate() const { return may_be_lcp_candidate_; }
+   int repetition_count() const { return repetition_count_; }
+   bool ShouldAnimate() const;
+   AnimationSequenceId reset_animation_sequence_id() const {
+@@ -389,6 +390,12 @@ class CC_PAINT_EXPORT PaintImage {
+   // Whether this image has more than 8 bits per color channel.
+   bool is_high_bit_depth_ = false;
+ 
++  // Whether this image may untimately be a candidate for Largest Contentful
++  // Paint. The final LCP contribution of an image is unknown until we present
++  // it, but this flag is intended for metrics on when we do not present the
++  // image when the system claims.
++  bool may_be_lcp_candidate_ = false;
++
+   // An incrementing sequence number maintained by the painter to indicate if
+   // this animation should be reset in the compositor. Incrementing this number
+   // will reset this animation in the compositor for the first frame which has a
+diff --git cc/paint/paint_image_builder.h cc/paint/paint_image_builder.h
+index 008d0fa5dc074..f75c3ffc06e02 100644
+--- cc/paint/paint_image_builder.h
++++ cc/paint/paint_image_builder.h
+@@ -87,6 +87,10 @@ class CC_PAINT_EXPORT PaintImageBuilder {
+     paint_image_.is_high_bit_depth_ = is_high_bit_depth;
+     return std::move(*this);
+   }
++  PaintImageBuilder&& set_may_be_lcp_candidate(bool may_be_lcp_candidate) {
++    paint_image_.may_be_lcp_candidate_ = may_be_lcp_candidate;
++    return std::move(*this);
++  }
+   PaintImageBuilder&& set_repetition_count(int count) {
+     paint_image_.repetition_count_ = count;
+     return std::move(*this);
+diff --git third_party/blink/renderer/core/paint/box_painter_base.cc third_party/blink/renderer/core/paint/box_painter_base.cc
+index da3e56c7b2f98..0b80634f3e2e2 100644
+--- third_party/blink/renderer/core/paint/box_painter_base.cc
++++ third_party/blink/renderer/core/paint/box_painter_base.cc
+@@ -527,7 +527,8 @@ void DrawTiledBackground(LocalFrame* frame,
+                          Image* image,
+                          const BackgroundImageGeometry& geometry,
+                          SkBlendMode op,
+-                         RespectImageOrientationEnum respect_orientation) {
++                         RespectImageOrientationEnum respect_orientation,
++                         bool image_may_be_lcp_candidate) {
+   DCHECK(!geometry.TileSize().IsEmpty());
+ 
+   const gfx::RectF dest_rect(geometry.SnappedDestRect());
+@@ -543,7 +544,8 @@ void DrawTiledBackground(LocalFrame* frame,
+     auto image_auto_dark_mode = ImageClassifierHelper::GetImageAutoDarkMode(
+         *frame, style, dest_rect, *single_tile_src);
+     context.DrawImage(image, Image::kSyncDecode, image_auto_dark_mode,
+-                      dest_rect, &*single_tile_src, op, respect_orientation);
++                      dest_rect, &*single_tile_src, op, respect_orientation,
++                      image_may_be_lcp_candidate);
+     return;
+   }
+ 
+@@ -589,7 +591,7 @@ void DrawTiledBackground(LocalFrame* frame,
+   // it into the snapped_dest_rect using phase from one_tile_rect and the
+   // given repeat spacing. Note the phase is already scaled.
+   context.DrawImageTiled(image, dest_rect, tiling_info, image_auto_dark_mode,
+-                         op, respect_orientation);
++                         op, respect_orientation, image_may_be_lcp_candidate);
+ }
+ 
+ scoped_refptr<Image> GetBGColorPaintWorkletImage(const Document* document,
+@@ -632,7 +634,7 @@ bool PaintBGColorWithPaintWorklet(const Document* document,
+   return true;
+ }
+ 
+-void DidDrawImage(
++bool WillDrawImage(
+     Node* node,
+     const Image& image,
+     const StyleImage& style_image,
+@@ -640,17 +642,19 @@ void DidDrawImage(
+     const gfx::RectF& image_rect) {
+   Node* generating_node = GeneratingNode(node);
+   if (!generating_node || !style_image.IsImageResource())
+-    return;
++    return false;
+   const gfx::Rect enclosing_rect = gfx::ToEnclosingRect(image_rect);
+-  PaintTimingDetector::NotifyBackgroundImagePaint(
+-      *generating_node, image, To<StyleFetchedImage>(style_image),
+-      current_paint_chunk_properties, enclosing_rect);
++  bool image_may_be_lcp_candidate =
++      PaintTimingDetector::NotifyBackgroundImagePaint(
++          *generating_node, image, To<StyleFetchedImage>(style_image),
++          current_paint_chunk_properties, enclosing_rect);
+ 
+   LocalDOMWindow* window = node->GetDocument().domWindow();
+   DCHECK(window);
+   ImageElementTiming::From(*window).NotifyBackgroundImagePainted(
+       *generating_node, To<StyleFetchedImage>(style_image),
+       current_paint_chunk_properties, enclosing_rect);
++  return image_may_be_lcp_candidate;
+ }
+ 
+ inline bool PaintFastBottomLayer(const Document* document,
+@@ -753,17 +757,19 @@ inline bool PaintFastBottomLayer(const Document* document,
+       inspector_paint_image_event::Data, node, *info.image,
+       gfx::RectF(image->Rect()), gfx::RectF(image_border.Rect()));
+ 
++  bool may_be_lcp_candidate =
++      WillDrawImage(node, *image, *info.image,
++                    context.GetPaintController().CurrentPaintChunkProperties(),
++                    image_border.Rect());
++
+   auto image_auto_dark_mode = ImageClassifierHelper::GetImageAutoDarkMode(
+       *document->GetFrame(), style, image_border.Rect(), src_rect);
+   // Since there is no way for the developer to specify decode behavior, use
+   // kSync by default.
+   context.DrawImageRRect(image, Image::kSyncDecode, image_auto_dark_mode,
+                          image_border, src_rect, composite_op,
+-                         info.respect_image_orientation);
++                         info.respect_image_orientation, may_be_lcp_candidate);
+ 
+-  DidDrawImage(node, *image, *info.image,
+-               context.GetPaintController().CurrentPaintChunkProperties(),
+-               image_border.Rect());
+   return true;
+ }
+ 
+@@ -882,11 +888,13 @@ void PaintFillLayerBackground(const Document* document,
+         TRACE_DISABLED_BY_DEFAULT("devtools.timeline"), "PaintImage",
+         inspector_paint_image_event::Data, node, *info.image,
+         gfx::RectF(image->Rect()), gfx::RectF(scrolled_paint_rect));
++    bool may_be_lcp_candidate = WillDrawImage(
++        node, *image, *info.image,
++        context.GetPaintController().CurrentPaintChunkProperties(),
++        gfx::RectF(geometry.SnappedDestRect()));
+     DrawTiledBackground(document->GetFrame(), context, style, image, geometry,
+-                        composite_op, info.respect_image_orientation);
+-    DidDrawImage(node, *image, *info.image,
+-                 context.GetPaintController().CurrentPaintChunkProperties(),
+-                 gfx::RectF(geometry.SnappedDestRect()));
++                        composite_op, info.respect_image_orientation,
++                        may_be_lcp_candidate);
+   }
+ }
+ 
+diff --git third_party/blink/renderer/core/paint/image_paint_timing_detector.cc third_party/blink/renderer/core/paint/image_paint_timing_detector.cc
+index 1d209b3dd3f74..946d5da0ac0ea 100644
+--- third_party/blink/renderer/core/paint/image_paint_timing_detector.cc
++++ third_party/blink/renderer/core/paint/image_paint_timing_detector.cc
+@@ -277,7 +277,7 @@ void ImageRecordsManager::AssignPaintTimeToRegisteredQueuedRecords(
+   }
+ }
+ 
+-void ImagePaintTimingDetector::RecordImage(
++bool ImagePaintTimingDetector::RecordImage(
+     const LayoutObject& object,
+     const gfx::Size& intrinsic_size,
+     const MediaTiming& media_timing,
+@@ -287,12 +287,12 @@ void ImagePaintTimingDetector::RecordImage(
+   Node* node = object.GetNode();
+ 
+   if (!node)
+-    return;
++    return false;
+ 
+   // Before the image resource starts loading, <img> has no size info. We wait
+   // until the size is known.
+   if (image_border.IsEmpty())
+-    return;
++    return false;
+ 
+   RecordId record_id = std::make_pair(&object, &media_timing);
+ 
+@@ -311,14 +311,14 @@ void ImagePaintTimingDetector::RecordImage(
+       records_manager_.MaybeUpdateLargestIgnoredImage(
+           record_id, rect_size, image_border, mapped_visual_rect);
+     }
+-    return;
++    return false;
+   }
+ 
+   if (records_manager_.IsRecordedImage(record_id)) {
+     base::WeakPtr<ImageRecord> record =
+         records_manager_.GetPendingImage(record_id);
+     if (!record)
+-      return;
++      return false;
+     if (ShouldReportAnimatedImages() && media_timing.IsPaintedFirstFrame()) {
+       added_entry_in_latest_frame_ |=
+           records_manager_.OnFirstAnimatedFramePainted(record_id, frame_index_);
+@@ -334,8 +334,9 @@ void ImagePaintTimingDetector::RecordImage(
+         visualizer->DumpImageDebuggingRect(object, mapped_visual_rect,
+                                            media_timing);
+       }
++      return true;
+     }
+-    return;
++    return false;
+   }
+ 
+   gfx::RectF mapped_visual_rect =
+@@ -352,7 +353,7 @@ void ImagePaintTimingDetector::RecordImage(
+   bool added_pending = records_manager_.RecordFirstPaintAndReturnIsPending(
+       record_id, rect_size, image_border, mapped_visual_rect, bpp);
+   if (!added_pending)
+-    return;
++    return false;
+ 
+   if (ShouldReportAnimatedImages() && media_timing.IsPaintedFirstFrame()) {
+     added_entry_in_latest_frame_ |=
+@@ -361,7 +362,9 @@ void ImagePaintTimingDetector::RecordImage(
+   if (media_timing.IsSufficientContentLoadedForPaint()) {
+     records_manager_.OnImageLoaded(record_id, frame_index_, style_image);
+     added_entry_in_latest_frame_ = true;
++    return true;
+   }
++  return false;
+ }
+ 
+ uint64_t ImagePaintTimingDetector::ComputeImageRectSize(
+diff --git third_party/blink/renderer/core/paint/image_paint_timing_detector.h third_party/blink/renderer/core/paint/image_paint_timing_detector.h
+index b21059065727e..2af69840ca396 100644
+--- third_party/blink/renderer/core/paint/image_paint_timing_detector.h
++++ third_party/blink/renderer/core/paint/image_paint_timing_detector.h
+@@ -243,8 +243,10 @@ class CORE_EXPORT ImagePaintTimingDetector final
+   // Record an image paint. This method covers both img and background image. In
+   // the case of a normal img, the last parameter will be nullptr. This
+   // parameter is needed only for the purposes of plumbing the correct loadTime
+-  // value to the ImageRecord.
+-  void RecordImage(const LayoutObject&,
++  // value to the ImageRecord. The method returns true if the image is a
++  // candidate for LargestContentfulPaint. That is, if the image is larger
++  // on screen than the current best candidate.
++  bool RecordImage(const LayoutObject&,
+                    const gfx::Size& intrinsic_size,
+                    const MediaTiming&,
+                    const PropertyTreeStateOrAlias& current_paint_properties,
+diff --git third_party/blink/renderer/core/paint/image_painter.cc third_party/blink/renderer/core/paint/image_painter.cc
+index d041b4c13e86e..6d10320098e23 100644
+--- third_party/blink/renderer/core/paint/image_painter.cc
++++ third_party/blink/renderer/core/paint/image_painter.cc
+@@ -260,10 +260,10 @@ void ImagePainter::PaintIntoRect(GraphicsContext& context,
+       *layout_image_.GetFrame(), layout_image_.StyleRef(),
+       gfx::RectF(pixel_snapped_dest_rect), src_rect);
+ 
+-  context.DrawImage(image.get(), decode_mode, image_auto_dark_mode,
+-                    gfx::RectF(pixel_snapped_dest_rect), &src_rect,
+-                    SkBlendMode::kSrcOver, respect_orientation);
+-
++  // At this point we have all the necessary information to report paint
++  // timing data. Do so now in order to mark the resulting PaintImage as
++  // an LCP candidate.
++  bool image_may_be_lcp_candidate = false;
+   if (ImageResourceContent* image_content = image_resource.CachedImage()) {
+     if ((IsA<HTMLImageElement>(node) || IsA<HTMLVideoElement>(node)) &&
+         image_content->IsLoaded()) {
+@@ -274,11 +274,16 @@ void ImagePainter::PaintIntoRect(GraphicsContext& context,
+           context.GetPaintController().CurrentPaintChunkProperties(),
+           pixel_snapped_dest_rect);
+     }
+-    PaintTimingDetector::NotifyImagePaint(
++    image_may_be_lcp_candidate = PaintTimingDetector::NotifyImagePaint(
+         layout_image_, image->Size(), *image_content,
+         context.GetPaintController().CurrentPaintChunkProperties(),
+         pixel_snapped_dest_rect);
+   }
++
++  context.DrawImage(image.get(), decode_mode, image_auto_dark_mode,
++                    gfx::RectF(pixel_snapped_dest_rect), &src_rect,
++                    SkBlendMode::kSrcOver, respect_orientation,
++                    image_may_be_lcp_candidate);
+ }
+ 
+ }  // namespace blink
+diff --git third_party/blink/renderer/core/paint/paint_timing_detector.cc third_party/blink/renderer/core/paint/paint_timing_detector.cc
+index 08033ebd86561..4a0827802060c 100644
+--- third_party/blink/renderer/core/paint/paint_timing_detector.cc
++++ third_party/blink/renderer/core/paint/paint_timing_detector.cc
+@@ -113,7 +113,7 @@ void PaintTimingDetector::NotifyPaintFinished() {
+ }
+ 
+ // static
+-void PaintTimingDetector::NotifyBackgroundImagePaint(
++bool PaintTimingDetector::NotifyBackgroundImagePaint(
+     const Node& node,
+     const Image& image,
+     const StyleFetchedImage& style_image,
+@@ -122,48 +122,49 @@ void PaintTimingDetector::NotifyBackgroundImagePaint(
+   DCHECK(style_image.CachedImage());
+   LayoutObject* object = node.GetLayoutObject();
+   if (!object)
+-    return;
++    return false;
+   LocalFrameView* frame_view = object->GetFrameView();
+   if (!frame_view)
+-    return;
++    return false;
+ 
+   ImagePaintTimingDetector* detector =
+       frame_view->GetPaintTimingDetector().GetImagePaintTimingDetector();
+   if (!detector)
+-    return;
++    return false;
+ 
+   if (!IsBackgroundImageContentful(*object, image))
+-    return;
++    return false;
+ 
+   ImageResourceContent* cached_image = style_image.CachedImage();
+   DCHECK(cached_image);
+   // TODO(yoav): |image| and |cached_image.GetImage()| are not the same here in
+   // the case of SVGs. Figure out why and if we can remove this footgun.
+ 
+-  detector->RecordImage(*object, image.Size(), *cached_image,
+-                        current_paint_chunk_properties, &style_image,
+-                        image_border);
++  return detector->RecordImage(*object, image.Size(), *cached_image,
++                               current_paint_chunk_properties, &style_image,
++                               image_border);
+ }
+ 
+ // static
+-void PaintTimingDetector::NotifyImagePaint(
++bool PaintTimingDetector::NotifyImagePaint(
+     const LayoutObject& object,
+     const gfx::Size& intrinsic_size,
+     const MediaTiming& media_timing,
+     const PropertyTreeStateOrAlias& current_paint_chunk_properties,
+     const gfx::Rect& image_border) {
+   if (IgnorePaintTimingScope::ShouldIgnore())
+-    return;
++    return false;
+   LocalFrameView* frame_view = object.GetFrameView();
+   if (!frame_view)
+-    return;
++    return false;
+   ImagePaintTimingDetector* detector =
+       frame_view->GetPaintTimingDetector().GetImagePaintTimingDetector();
+   if (!detector)
+-    return;
++    return false;
+ 
+-  detector->RecordImage(object, intrinsic_size, media_timing,
+-                        current_paint_chunk_properties, nullptr, image_border);
++  return detector->RecordImage(object, intrinsic_size, media_timing,
++                               current_paint_chunk_properties, nullptr,
++                               image_border);
+ }
+ 
+ void PaintTimingDetector::NotifyImageFinished(const LayoutObject& object,
+diff --git third_party/blink/renderer/core/paint/paint_timing_detector.h third_party/blink/renderer/core/paint/paint_timing_detector.h
+index 29f5bec1ca151..fdc9a6a0a4d57 100644
+--- third_party/blink/renderer/core/paint/paint_timing_detector.h
++++ third_party/blink/renderer/core/paint/paint_timing_detector.h
+@@ -123,13 +123,19 @@ class CORE_EXPORT PaintTimingDetector
+  public:
+   PaintTimingDetector(LocalFrameView*);
+ 
+-  static void NotifyBackgroundImagePaint(
++  // Returns true if the image might ultimately be a candidate for largest
++  // paint, otherwise false. When this method is called we do not know the
++  // largest status for certain, because we need to wait for presentation.
++  // Hence the "maybe" return value.
++  static bool NotifyBackgroundImagePaint(
+       const Node&,
+       const Image&,
+       const StyleFetchedImage&,
+       const PropertyTreeStateOrAlias& current_paint_chunk_properties,
+       const gfx::Rect& image_border);
+-  static void NotifyImagePaint(
++  // Returns true if the image is a candidate for largest paint, otherwise
++  // false. See the comment for NotifyBackgroundImagePaint(...).
++  static bool NotifyImagePaint(
+       const LayoutObject&,
+       const gfx::Size& intrinsic_size,
+       const MediaTiming& media_timing,
+diff --git third_party/blink/renderer/core/paint/svg_image_painter.cc third_party/blink/renderer/core/paint/svg_image_painter.cc
+index a73cccf2400c0..99644d1096880 100644
+--- third_party/blink/renderer/core/paint/svg_image_painter.cc
++++ third_party/blink/renderer/core/paint/svg_image_painter.cc
+@@ -85,19 +85,8 @@ void SVGImagePainter::PaintForeground(const PaintInfo& paint_info) {
+         dest_rect, src_rect);
+   }
+ 
+-  ScopedInterpolationQuality interpolation_quality_scope(
+-      paint_info.context,
+-      layout_svg_image_.StyleRef().GetInterpolationQuality());
+-  Image::ImageDecodingMode decode_mode =
+-      image_element->GetDecodingModeForPainting(image->paint_image_id());
+-  auto image_auto_dark_mode = ImageClassifierHelper::GetImageAutoDarkMode(
+-      *layout_svg_image_.GetFrame(), layout_svg_image_.StyleRef(), dest_rect,
+-      src_rect);
+-  paint_info.context.DrawImage(image.get(), decode_mode, image_auto_dark_mode,
+-                               dest_rect, &src_rect, SkBlendMode::kSrcOver,
+-                               respect_orientation);
+-
+   ImageResourceContent* image_content = image_resource.CachedImage();
++  bool image_may_be_lcp_candidate = false;
+   if (image_content->IsLoaded()) {
+     LocalDOMWindow* window = layout_svg_image_.GetDocument().domWindow();
+     DCHECK(window);
+@@ -106,12 +95,24 @@ void SVGImagePainter::PaintForeground(const PaintInfo& paint_info) {
+         paint_info.context.GetPaintController().CurrentPaintChunkProperties(),
+         gfx::ToEnclosingRect(dest_rect));
+   }
+-  PaintTimingDetector::NotifyImagePaint(
++  image_may_be_lcp_candidate = PaintTimingDetector::NotifyImagePaint(
+       layout_svg_image_, image->Size(), *image_content,
+       paint_info.context.GetPaintController().CurrentPaintChunkProperties(),
+       gfx::ToEnclosingRect(dest_rect));
+   PaintTiming& timing = PaintTiming::From(layout_svg_image_.GetDocument());
+   timing.MarkFirstContentfulPaint();
++
++  ScopedInterpolationQuality interpolation_quality_scope(
++      paint_info.context,
++      layout_svg_image_.StyleRef().GetInterpolationQuality());
++  Image::ImageDecodingMode decode_mode =
++      image_element->GetDecodingModeForPainting(image->paint_image_id());
++  auto image_auto_dark_mode = ImageClassifierHelper::GetImageAutoDarkMode(
++      *layout_svg_image_.GetFrame(), layout_svg_image_.StyleRef(), dest_rect,
++      src_rect);
++  paint_info.context.DrawImage(image.get(), decode_mode, image_auto_dark_mode,
++                               dest_rect, &src_rect, SkBlendMode::kSrcOver,
++                               respect_orientation, image_may_be_lcp_candidate);
+ }
+ 
+ gfx::SizeF SVGImagePainter::ComputeImageViewportSize() const {
+diff --git third_party/blink/renderer/platform/graphics/accelerated_static_bitmap_image.cc third_party/blink/renderer/platform/graphics/accelerated_static_bitmap_image.cc
+index 1e45dfc1eee46..53ea5f8a9d9e3 100644
+--- third_party/blink/renderer/platform/graphics/accelerated_static_bitmap_image.cc
++++ third_party/blink/renderer/platform/graphics/accelerated_static_bitmap_image.cc
+@@ -225,10 +225,13 @@ void AcceleratedStaticBitmapImage::Draw(cc::PaintCanvas* canvas,
+     return;
+   auto paint_image_decoding_mode =
+       ToPaintImageDecodingMode(draw_options.decode_mode);
+-  if (paint_image.decoding_mode() != paint_image_decoding_mode) {
+-    paint_image = PaintImageBuilder::WithCopy(std::move(paint_image))
+-                      .set_decoding_mode(paint_image_decoding_mode)
+-                      .TakePaintImage();
++  if (paint_image.decoding_mode() != paint_image_decoding_mode ||
++      paint_image.may_be_lcp_candidate() != draw_options.may_be_lcp_candidate) {
++    paint_image =
++        PaintImageBuilder::WithCopy(std::move(paint_image))
++            .set_decoding_mode(paint_image_decoding_mode)
++            .set_may_be_lcp_candidate(draw_options.may_be_lcp_candidate)
++            .TakePaintImage();
+   }
+   StaticBitmapImage::DrawHelper(canvas, flags, dst_rect, src_rect, draw_options,
+                                 paint_image);
+diff --git third_party/blink/renderer/platform/graphics/bitmap_image.cc third_party/blink/renderer/platform/graphics/bitmap_image.cc
+index 46f42d7df8804..bec446e88d579 100644
+--- third_party/blink/renderer/platform/graphics/bitmap_image.cc
++++ third_party/blink/renderer/platform/graphics/bitmap_image.cc
+@@ -263,9 +263,11 @@ void BitmapImage::Draw(cc::PaintCanvas* canvas,
+ 
+   auto paint_image_decoding_mode =
+       ToPaintImageDecodingMode(draw_options.decode_mode);
+-  if (image.decoding_mode() != paint_image_decoding_mode) {
++  if (image.decoding_mode() != paint_image_decoding_mode ||
++      image.may_be_lcp_candidate() != draw_options.may_be_lcp_candidate) {
+     image = PaintImageBuilder::WithCopy(std::move(image))
+                 .set_decoding_mode(paint_image_decoding_mode)
++                .set_may_be_lcp_candidate(draw_options.may_be_lcp_candidate)
+                 .TakePaintImage();
+   }
+ 
+diff --git third_party/blink/renderer/platform/graphics/graphics_context.cc third_party/blink/renderer/platform/graphics/graphics_context.cc
+index 63ce53aba6121..8f967d93907a8 100644
+--- third_party/blink/renderer/platform/graphics/graphics_context.cc
++++ third_party/blink/renderer/platform/graphics/graphics_context.cc
+@@ -751,7 +751,8 @@ void GraphicsContext::DrawImage(
+     const gfx::RectF& dest,
+     const gfx::RectF* src_ptr,
+     SkBlendMode op,
+-    RespectImageOrientationEnum should_respect_image_orientation) {
++    RespectImageOrientationEnum should_respect_image_orientation,
++    bool image_may_be_lcp_candidate) {
+   if (!image)
+     return;
+ 
+@@ -764,7 +765,8 @@ void GraphicsContext::DrawImage(
+   DarkModeFilter* dark_mode_filter = GetDarkModeFilterForImage(auto_dark_mode);
+   ImageDrawOptions draw_options(
+       dark_mode_filter, sampling, should_respect_image_orientation,
+-      Image::kClampImageToSourceRect, decode_mode, auto_dark_mode.enabled);
++      Image::kClampImageToSourceRect, decode_mode, auto_dark_mode.enabled,
++      image_may_be_lcp_candidate);
+ 
+   image->Draw(canvas_, image_flags, dest, src, draw_options);
+   paint_controller_.SetImagePainted();
+@@ -777,13 +779,14 @@ void GraphicsContext::DrawImageRRect(
+     const FloatRoundedRect& dest,
+     const gfx::RectF& src_rect,
+     SkBlendMode op,
+-    RespectImageOrientationEnum respect_orientation) {
++    RespectImageOrientationEnum respect_orientation,
++    bool image_may_be_lcp_candidate) {
+   if (!image)
+     return;
+ 
+   if (!dest.IsRounded()) {
+     DrawImage(image, decode_mode, auto_dark_mode, dest.Rect(), &src_rect, op,
+-              respect_orientation);
++              respect_orientation, image_may_be_lcp_candidate);
+     return;
+   }
+ 
+@@ -803,7 +806,8 @@ void GraphicsContext::DrawImageRRect(
+   DarkModeFilter* dark_mode_filter = GetDarkModeFilterForImage(auto_dark_mode);
+   ImageDrawOptions draw_options(dark_mode_filter, sampling, respect_orientation,
+                                 Image::kClampImageToSourceRect, decode_mode,
+-                                auto_dark_mode.enabled);
++                                auto_dark_mode.enabled,
++                                image_may_be_lcp_candidate);
+ 
+   bool use_shader = (visible_src == src_rect) &&
+                     (respect_orientation == kDoNotRespectImageOrientation ||
+@@ -865,7 +869,8 @@ void GraphicsContext::DrawImageTiled(
+     const ImageTilingInfo& tiling_info,
+     const ImageAutoDarkMode& auto_dark_mode,
+     SkBlendMode op,
+-    RespectImageOrientationEnum respect_orientation) {
++    RespectImageOrientationEnum respect_orientation,
++    bool image_may_be_lcp_candidate) {
+   if (!image)
+     return;
+ 
+@@ -875,7 +880,8 @@ void GraphicsContext::DrawImageTiled(
+   DarkModeFilter* dark_mode_filter = GetDarkModeFilterForImage(auto_dark_mode);
+   ImageDrawOptions draw_options(dark_mode_filter, sampling, respect_orientation,
+                                 Image::kClampImageToSourceRect,
+-                                Image::kSyncDecode, auto_dark_mode.enabled);
++                                Image::kSyncDecode, auto_dark_mode.enabled,
++                                image_may_be_lcp_candidate);
+ 
+   image->DrawPattern(*this, image_flags, dest_rect, tiling_info, draw_options);
+   paint_controller_.SetImagePainted();
+diff --git third_party/blink/renderer/platform/graphics/graphics_context.h third_party/blink/renderer/platform/graphics/graphics_context.h
+index 7804b258c1996..329f05d66f068 100644
+--- third_party/blink/renderer/platform/graphics/graphics_context.h
++++ third_party/blink/renderer/platform/graphics/graphics_context.h
+@@ -93,19 +93,22 @@ struct ImageDrawOptions {
+                             RespectImageOrientationEnum respect_orientation,
+                             Image::ImageClampingMode clamping_mode,
+                             Image::ImageDecodingMode decode_mode,
+-                            bool apply_dark_mode)
++                            bool apply_dark_mode,
++                            bool may_be_lcp_candidate)
+       : dark_mode_filter(dark_mode_filter),
+         sampling_options(sampling_options),
+         respect_orientation(respect_orientation),
+         clamping_mode(clamping_mode),
+         decode_mode(decode_mode),
+-        apply_dark_mode(apply_dark_mode) {}
++        apply_dark_mode(apply_dark_mode),
++        may_be_lcp_candidate(may_be_lcp_candidate) {}
+   DarkModeFilter* dark_mode_filter = nullptr;
+   SkSamplingOptions sampling_options;
+   RespectImageOrientationEnum respect_orientation = kRespectImageOrientation;
+   Image::ImageClampingMode clamping_mode = Image::kClampImageToSourceRect;
+   Image::ImageDecodingMode decode_mode = Image::kSyncDecode;
+   bool apply_dark_mode = false;
++  bool may_be_lcp_candidate = false;
+ };
+ 
+ struct AutoDarkMode {
+@@ -319,20 +322,23 @@ class PLATFORM_EXPORT GraphicsContext {
+                  const gfx::RectF& dest_rect,
+                  const gfx::RectF* src_rect = nullptr,
+                  SkBlendMode = SkBlendMode::kSrcOver,
+-                 RespectImageOrientationEnum = kRespectImageOrientation);
++                 RespectImageOrientationEnum = kRespectImageOrientation,
++                 bool image_may_be_lcp_candidate = false);
+   void DrawImageRRect(Image*,
+                       Image::ImageDecodingMode,
+                       const ImageAutoDarkMode& auto_dark_mode,
+                       const FloatRoundedRect& dest,
+                       const gfx::RectF& src_rect,
+                       SkBlendMode = SkBlendMode::kSrcOver,
+-                      RespectImageOrientationEnum = kRespectImageOrientation);
++                      RespectImageOrientationEnum = kRespectImageOrientation,
++                      bool image_may_be_lcp_candidate = false);
+   void DrawImageTiled(Image* image,
+                       const gfx::RectF& dest_rect,
+                       const ImageTilingInfo& tiling_info,
+                       const ImageAutoDarkMode& auto_dark_mode,
+                       SkBlendMode = SkBlendMode::kSrcOver,
+-                      RespectImageOrientationEnum = kRespectImageOrientation);
++                      RespectImageOrientationEnum = kRespectImageOrientation,
++                      bool image_may_be_lcp_candidate = false);
+ 
+   // These methods write to the canvas.
+   // Also drawLine(const gfx::Point& point1, const gfx::Point& point2) and
+diff --git third_party/blink/renderer/platform/graphics/unaccelerated_static_bitmap_image.cc third_party/blink/renderer/platform/graphics/unaccelerated_static_bitmap_image.cc
+index 943ca0078fe22..adbcc7d685242 100644
+--- third_party/blink/renderer/platform/graphics/unaccelerated_static_bitmap_image.cc
++++ third_party/blink/renderer/platform/graphics/unaccelerated_static_bitmap_image.cc
+@@ -79,8 +79,14 @@ void UnacceleratedStaticBitmapImage::Draw(
+     const gfx::RectF& src_rect,
+     const ImageDrawOptions& draw_options) {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++  auto image = PaintImageForCurrentFrame();
++  if (image.may_be_lcp_candidate() != draw_options.may_be_lcp_candidate) {
++    image = PaintImageBuilder::WithCopy(std::move(image))
++                .set_may_be_lcp_candidate(draw_options.may_be_lcp_candidate)
++                .TakePaintImage();
++  }
+   StaticBitmapImage::DrawHelper(canvas, flags, dst_rect, src_rect, draw_options,
+-                                PaintImageForCurrentFrame());
++                                image);
+ }
+ 
+ PaintImage UnacceleratedStaticBitmapImage::PaintImageForCurrentFrame() {

--- a/patch/patches/chrome_browser.patch
+++ b/patch/patches/chrome_browser.patch
@@ -1,5 +1,5 @@
 diff --git chrome/browser/BUILD.gn chrome/browser/BUILD.gn
-index 3833b9c12e0cf..2e53204e17565 100644
+index 817539af42794..57c9def28ff59 100644
 --- chrome/browser/BUILD.gn
 +++ chrome/browser/BUILD.gn
 @@ -11,6 +11,7 @@ import("//build/config/compiler/pgo/pgo.gni")

--- a/patch/patches/media_access_handler.patch
+++ b/patch/patches/media_access_handler.patch
@@ -1,0 +1,73 @@
+diff --git chrome/browser/permissions/chrome_permissions_client.cc chrome/browser/permissions/chrome_permissions_client.cc
+index 88b4e168bed57..7b4c88a59272c 100644
+--- chrome/browser/permissions/chrome_permissions_client.cc
++++ chrome/browser/permissions/chrome_permissions_client.cc
+@@ -12,6 +12,7 @@
+ #include "base/strings/string_util.h"
+ #include "build/build_config.h"
+ #include "build/chromeos_buildflags.h"
++#include "cef/libcef/features/runtime.h"
+ #include "chrome/browser/bluetooth/bluetooth_chooser_context_factory.h"
+ #include "chrome/browser/content_settings/cookie_settings_factory.h"
+ #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+@@ -212,6 +213,9 @@ permissions::PermissionManager* ChromePermissionsClient::GetPermissionManager(
+ double ChromePermissionsClient::GetSiteEngagementScore(
+     content::BrowserContext* browser_context,
+     const GURL& origin) {
++  // No SiteEngagementService with the Alloy runtime.
++  if (cef::IsAlloyRuntimeEnabled())
++    return 0.0;
+   return site_engagement::SiteEngagementService::Get(
+              Profile::FromBrowserContext(browser_context))
+       ->GetScore(origin);
+diff --git chrome/browser/ui/permission_bubble/permission_prompt.h chrome/browser/ui/permission_bubble/permission_prompt.h
+index c2836d15eba30..0c03c2b4666a6 100644
+--- chrome/browser/ui/permission_bubble/permission_prompt.h
++++ chrome/browser/ui/permission_bubble/permission_prompt.h
+@@ -11,6 +11,13 @@ namespace content {
+ class WebContents;
+ }
+ 
++using CreatePermissionPromptFunctionPtr =
++    std::unique_ptr<permissions::PermissionPrompt> (*)(
++        content::WebContents* web_contents,
++        permissions::PermissionPrompt::Delegate* delegate,
++        bool* default_handling);
++void SetCreatePermissionPromptFunction(CreatePermissionPromptFunctionPtr);
++
+ // Factory function to create permission prompts for chrome.
+ std::unique_ptr<permissions::PermissionPrompt> CreatePermissionPrompt(
+     content::WebContents* web_contents,
+diff --git chrome/browser/ui/views/permission_bubble/permission_prompt_impl.cc chrome/browser/ui/views/permission_bubble/permission_prompt_impl.cc
+index 6b9c170cc6f91..cba6687ca2201 100644
+--- chrome/browser/ui/views/permission_bubble/permission_prompt_impl.cc
++++ chrome/browser/ui/views/permission_bubble/permission_prompt_impl.cc
+@@ -77,11 +77,28 @@ bool ShouldBubbleStartOpen(permissions::PermissionPrompt::Delegate* delegate) {
+   return false;
+ }
+ 
++CreatePermissionPromptFunctionPtr g_create_permission_prompt_ptr = nullptr;
++
+ }  // namespace
+ 
++void SetCreatePermissionPromptFunction(
++    CreatePermissionPromptFunctionPtr ptr) {
++  g_create_permission_prompt_ptr = ptr;
++}
++
+ std::unique_ptr<permissions::PermissionPrompt> CreatePermissionPrompt(
+     content::WebContents* web_contents,
+     permissions::PermissionPrompt::Delegate* delegate) {
++  if (g_create_permission_prompt_ptr) {
++    bool default_handling = true;
++    auto prompt = g_create_permission_prompt_ptr(web_contents, delegate,
++                                                 &default_handling);
++    if (prompt)
++      return prompt;
++    if (!default_handling)
++      return nullptr;
++  }
++
+   Browser* browser = chrome::FindBrowserWithWebContents(web_contents);
+   if (!browser) {
+     DLOG(WARNING) << "Permission prompt suppressed because the WebContents is "

--- a/patch/patches/osr_nthandle.patch
+++ b/patch/patches/osr_nthandle.patch
@@ -1,0 +1,1002 @@
+diff --git chrome/browser/vr/win/graphics_delegate_win.cc chrome/browser/vr/win/graphics_delegate_win.cc
+index 0916ebfce4db4..738fb8487d9ff 100644
+--- chrome/browser/vr/win/graphics_delegate_win.cc
++++ chrome/browser/vr/win/graphics_delegate_win.cc
+@@ -142,8 +142,8 @@ mojo::PlatformHandle GraphicsDelegateWin::GetTexture() {
+   if (!gpu_memory_buffer_)
+     return {};
+ 
+-  gfx::GpuMemoryBufferHandle gpu_handle = gpu_memory_buffer_->CloneHandle();
+-  return mojo::PlatformHandle(std::move(gpu_handle.dxgi_handle));
++  //gfx::GpuMemoryBufferHandle gpu_handle = gpu_memory_buffer_->CloneHandle();
++  return mojo::PlatformHandle(/*std::move(gpu_handle.dxgi_handle)*/);
+ }
+ 
+ const gpu::SyncToken& GraphicsDelegateWin::GetSyncToken() {
+diff --git components/viz/service/frame_sinks/external_begin_frame_source_mojo.cc components/viz/service/frame_sinks/external_begin_frame_source_mojo.cc
+index 9ce1f5a11b28c..abbd8ecce4e0a 100644
+--- components/viz/service/frame_sinks/external_begin_frame_source_mojo.cc
++++ components/viz/service/frame_sinks/external_begin_frame_source_mojo.cc
+@@ -22,6 +22,13 @@ ExternalBeginFrameSourceMojo::ExternalBeginFrameSourceMojo(
+ }
+ 
+ ExternalBeginFrameSourceMojo::~ExternalBeginFrameSourceMojo() {
++  if (pending_frame_callback_) {
++    BeginFrameAck nak(last_begin_frame_args_.frame_id.source_id,
++                      last_begin_frame_args_.frame_id.sequence_number,
++                      /*has_damage=*/false);
++    std::move(pending_frame_callback_).Run(nak);
++  }
++
+   frame_sink_manager_->RemoveObserver(this);
+   DCHECK(!display_);
+ }
+diff --git content/browser/compositor/viz_process_transport_factory.cc content/browser/compositor/viz_process_transport_factory.cc
+index 8a1e93995b316..d35121fead1c2 100644
+--- content/browser/compositor/viz_process_transport_factory.cc
++++ content/browser/compositor/viz_process_transport_factory.cc
+@@ -392,6 +392,8 @@ void VizProcessTransportFactory::OnEstablishedGpuChannel(
+       compositor_data.display_client->GetBoundRemote(resize_task_runner_);
+ 
+   if (compositor->use_external_begin_frame_control()) {
++    compositor_data.external_begin_frame_controller = {};
++
+     root_params->external_begin_frame_controller =
+         compositor_data.external_begin_frame_controller
+             .BindNewEndpointAndPassReceiver();
+diff --git device/vr/openxr/openxr_api_wrapper.cc device/vr/openxr/openxr_api_wrapper.cc
+index cd30680def1a3..5e176e4c1f2d5 100644
+--- device/vr/openxr/openxr_api_wrapper.cc
++++ device/vr/openxr/openxr_api_wrapper.cc
+@@ -688,7 +688,7 @@ void OpenXrApiWrapper::CreateSharedMailboxes() {
+     }
+ 
+     gfx::GpuMemoryBufferHandle gpu_memory_buffer_handle;
+-    gpu_memory_buffer_handle.dxgi_handle.Set(shared_handle);
++    //gpu_memory_buffer_handle.dxgi_handle.Set(shared_handle);
+     gpu_memory_buffer_handle.dxgi_token = gfx::DXGIHandleToken();
+     gpu_memory_buffer_handle.type = gfx::DXGI_SHARED_HANDLE;
+ 
+diff --git gpu/command_buffer/service/dxgi_shared_handle_manager.cc gpu/command_buffer/service/dxgi_shared_handle_manager.cc
+index 55c421bef9211..6bdd085a63532 100644
+--- gpu/command_buffer/service/dxgi_shared_handle_manager.cc
++++ gpu/command_buffer/service/dxgi_shared_handle_manager.cc
+@@ -16,7 +16,9 @@ namespace gpu {
+ 
+ namespace {
+ 
+-bool IsSameHandle(HANDLE handle, HANDLE other) {
++bool IsSameHandle(uint64_t handle, uint64_t other) {
++  return handle == other;
++#if 0
+   using PFN_COMPARE_OBJECT_HANDLES =
+       BOOL(WINAPI*)(HANDLE hFirstObjectHandle, HANDLE hSecondObjectHandle);
+   static PFN_COMPARE_OBJECT_HANDLES compare_object_handles_fn =
+@@ -39,6 +41,7 @@ bool IsSameHandle(HANDLE handle, HANDLE other) {
+   // case since there's no other way to check if the handles refer to the same
+   // D3D11 texture and IsSameHandle is only used as a sanity test.
+   return true;
++#endif
+ }
+ 
+ }  // namespace
+@@ -47,7 +50,7 @@ DXGISharedHandleState::DXGISharedHandleState(
+     base::PassKey<DXGISharedHandleManager>,
+     scoped_refptr<DXGISharedHandleManager> manager,
+     gfx::DXGIHandleToken token,
+-    base::win::ScopedHandle shared_handle,
++    uint64_t shared_handle,
+     Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture)
+     : base::subtle::RefCountedThreadSafeBase(kRefCountPreference),
+       manager_(std::move(manager)),
+@@ -158,9 +161,7 @@ DXGISharedHandleManager::~DXGISharedHandleManager() {
+ scoped_refptr<DXGISharedHandleState>
+ DXGISharedHandleManager::GetOrCreateSharedHandleState(
+     gfx::DXGIHandleToken token,
+-    base::win::ScopedHandle shared_handle) {
+-  DCHECK(shared_handle.IsValid());
+-
++    uint64_t shared_handle) {
+   base::AutoLock auto_lock(lock_);
+ 
+   auto it = shared_handle_state_map_.find(token);
+@@ -169,7 +170,7 @@ DXGISharedHandleManager::GetOrCreateSharedHandleState(
+     DCHECK(state);
+     // If there's already a shared handle associated with the token, it should
+     // refer to the same D3D11 texture (or kernel object).
+-    if (!IsSameHandle(shared_handle.Get(), state->GetSharedHandle())) {
++    if (!IsSameHandle(shared_handle, state->GetSharedHandle())) {
+       DLOG(ERROR) << "Existing shared handle for token doesn't match";
+       return nullptr;
+     }
+@@ -185,8 +186,8 @@ DXGISharedHandleManager::GetOrCreateSharedHandleState(
+   }
+ 
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+-  hr = d3d11_device1->OpenSharedResource1(shared_handle.Get(),
+-                                          IID_PPV_ARGS(&d3d11_texture));
++  hr = d3d11_device_->OpenSharedResource(HANDLE(shared_handle),
++                                         IID_PPV_ARGS(&d3d11_texture));
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "Unable to open shared resource from DXGI handle. Error: "
+                 << logging::SystemErrorCodeToString(hr);
+@@ -205,9 +206,9 @@ DXGISharedHandleManager::GetOrCreateSharedHandleState(
+ 
+ scoped_refptr<DXGISharedHandleState>
+ DXGISharedHandleManager::CreateAnonymousSharedHandleState(
+-    base::win::ScopedHandle shared_handle,
++    uint64_t shared_handle,
+     Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture) {
+-  DCHECK(shared_handle.IsValid());
++  //DCHECK(shared_handle.IsValid());
+   DCHECK(d3d11_texture);
+ 
+   base::AutoLock auto_lock(lock_);
+diff --git gpu/command_buffer/service/dxgi_shared_handle_manager.h gpu/command_buffer/service/dxgi_shared_handle_manager.h
+index 845f9a0777ade..09789fe16504c 100644
+--- gpu/command_buffer/service/dxgi_shared_handle_manager.h
++++ gpu/command_buffer/service/dxgi_shared_handle_manager.h
+@@ -49,7 +49,7 @@ class GPU_GLES2_EXPORT DXGISharedHandleState
+   DXGISharedHandleState(base::PassKey<DXGISharedHandleManager>,
+                         scoped_refptr<DXGISharedHandleManager> manager,
+                         gfx::DXGIHandleToken token,
+-                        base::win::ScopedHandle shared_handle,
++                        uint64_t shared_handle,
+                         Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture);
+ 
+   DXGISharedHandleState(const DXGISharedHandleState&) = delete;
+@@ -58,7 +58,7 @@ class GPU_GLES2_EXPORT DXGISharedHandleState
+   void AddRef() const;
+   void Release() const;
+ 
+-  HANDLE GetSharedHandle() const { return shared_handle_.Get(); }
++  uint64_t GetSharedHandle() const { return shared_handle_; }
+ 
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture() const {
+     return d3d11_texture_;
+@@ -84,7 +84,7 @@ class GPU_GLES2_EXPORT DXGISharedHandleState
+   // keyed mutex. To create the corresponding D3D12 interface, pass the handle
+   // stored in |shared_handle_| to ID3D12Device::OpenSharedHandle. Only one
+   // component is allowed to read/write to the texture at a time.
+-  base::win::ScopedHandle shared_handle_;
++  uint64_t shared_handle_;
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture_;
+   Microsoft::WRL::ComPtr<IDXGIKeyedMutex> dxgi_keyed_mutex_;
+   bool acquired_for_d3d12_ = false;
+@@ -103,14 +103,14 @@ class GPU_GLES2_EXPORT DXGISharedHandleManager
+   // will refer to the same D3D11 texture. Returns a nullptr on error.
+   scoped_refptr<DXGISharedHandleState> GetOrCreateSharedHandleState(
+       gfx::DXGIHandleToken token,
+-      base::win::ScopedHandle shared_handle);
++      uint64_t shared_handle);
+ 
+   // Creates a new unique state for given |shared_handle| and |d3d11_texture|.
+   // No other state will have references to the same shared handle and texture.
+   // Useful when creating handles which are guaranteed to never be duplicated
+   // e.g. WebGPU usage shared image that only needs a handle for Dawn interop.
+   scoped_refptr<DXGISharedHandleState> CreateAnonymousSharedHandleState(
+-      base::win::ScopedHandle shared_handle,
++      uint64_t shared_handle,
+       Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture);
+ 
+   size_t GetSharedHandleMapSizeForTesting() const;
+diff --git gpu/command_buffer/service/dxgi_shared_handle_manager_unittest.cc gpu/command_buffer/service/dxgi_shared_handle_manager_unittest.cc
+index a0341b3426761..1cc5bb9114a1a 100644
+--- gpu/command_buffer/service/dxgi_shared_handle_manager_unittest.cc
++++ gpu/command_buffer/service/dxgi_shared_handle_manager_unittest.cc
+@@ -47,7 +47,7 @@ class DXGISharedHandleManagerTest : public testing::Test {
+     desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+     desc.CPUAccessFlags = 0;
+     desc.MiscFlags =
+-        D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED;
++        D3D11_RESOURCE_MISC_SHARED;
+ 
+     Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+     HRESULT hr = d3d11_device_->CreateTexture2D(&desc, nullptr, &d3d11_texture);
+diff --git gpu/command_buffer/service/shared_image_backing_d3d.cc gpu/command_buffer/service/shared_image_backing_d3d.cc
+index 0b2477bfc7b89..76423f9bce0d4 100644
+--- gpu/command_buffer/service/shared_image_backing_d3d.cc
++++ gpu/command_buffer/service/shared_image_backing_d3d.cc
+@@ -645,13 +645,14 @@ SharedImageBackingD3D::ProduceDawn(SharedImageManager* manager,
+   // Persistently open the shared handle by caching it on this backing.
+   if (!external_image_) {
+     DCHECK(dxgi_shared_handle_state_);
+-    const HANDLE shared_handle = dxgi_shared_handle_state_->GetSharedHandle();
+-    DCHECK(base::win::HandleTraits::IsHandleValid(shared_handle));
++    const uint64_t shared_handle = dxgi_shared_handle_state_->GetSharedHandle();
++    CHECK(false);
++    //DCHECK(base::win::HandleTraits::IsHandleValid(shared_handle));
+ 
+     dawn::native::d3d12::ExternalImageDescriptorDXGISharedHandle
+         externalImageDesc;
+     externalImageDesc.cTextureDescriptor = &texture_descriptor;
+-    externalImageDesc.sharedHandle = shared_handle;
++    externalImageDesc.sharedHandle = (HANDLE)shared_handle;
+ 
+     external_image_ = dawn::native::d3d12::ExternalImageDXGI::Create(
+         device, &externalImageDesc);
+diff --git gpu/command_buffer/service/shared_image_backing_factory_d3d.cc gpu/command_buffer/service/shared_image_backing_factory_d3d.cc
+index b2a5bb00ca9a4..acf380a32b321 100644
+--- gpu/command_buffer/service/shared_image_backing_factory_d3d.cc
++++ gpu/command_buffer/service/shared_image_backing_factory_d3d.cc
+@@ -107,7 +107,7 @@ scoped_refptr<DXGISharedHandleState> ValidateAndOpenSharedHandle(
+     gfx::GpuMemoryBufferHandle handle,
+     gfx::BufferFormat format,
+     const gfx::Size& size) {
+-  if (handle.type != gfx::DXGI_SHARED_HANDLE || !handle.dxgi_handle.IsValid()) {
++  if (handle.type != gfx::DXGI_SHARED_HANDLE) {
+     DLOG(ERROR) << "Invalid handle with type: " << handle.type;
+     return nullptr;
+   }
+@@ -350,8 +350,7 @@ SharedImageBackingFactoryD3D::CreateSharedImage(
+     desc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
+   }
+   desc.CPUAccessFlags = 0;
+-  desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-                   D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
++  desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+   HRESULT hr = d3d11_device_->CreateTexture2D(&desc, nullptr, &d3d11_texture);
+   if (FAILED(hr)) {
+@@ -364,7 +363,7 @@ SharedImageBackingFactoryD3D::CreateSharedImage(
+   d3d11_device_->SetPrivateData(WKPDID_D3DDebugObjectName, debug_label.length(),
+                                 debug_label.c_str());
+ 
+-  Microsoft::WRL::ComPtr<IDXGIResource1> dxgi_resource;
++  Microsoft::WRL::ComPtr<IDXGIResource> dxgi_resource;
+   hr = d3d11_texture.As(&dxgi_resource);
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "QueryInterface for IDXGIResource failed with error "
+@@ -373,8 +372,8 @@ SharedImageBackingFactoryD3D::CreateSharedImage(
+   }
+ 
+   HANDLE shared_handle;
+-  hr = dxgi_resource->CreateSharedHandle(
+-      nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr,
++  hr = dxgi_resource->GetSharedHandle(
++      //nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr,
+       &shared_handle);
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "Unable to create shared handle for DXGIResource "
+@@ -384,7 +383,7 @@ SharedImageBackingFactoryD3D::CreateSharedImage(
+ 
+   scoped_refptr<DXGISharedHandleState> dxgi_shared_handle_state =
+       dxgi_shared_handle_manager_->CreateAnonymousSharedHandleState(
+-          base::win::ScopedHandle(shared_handle), d3d11_texture);
++          uint64_t(shared_handle), d3d11_texture);
+ 
+   return SharedImageBackingD3D::CreateFromDXGISharedHandle(
+       mailbox, format, size, color_space, surface_origin, alpha_type, usage,
+diff --git gpu/command_buffer/service/shared_image_backing_factory_d3d_unittest.cc gpu/command_buffer/service/shared_image_backing_factory_d3d_unittest.cc
+index 8b5d4d52093f1..54efe92a32290 100644
+--- gpu/command_buffer/service/shared_image_backing_factory_d3d_unittest.cc
++++ gpu/command_buffer/service/shared_image_backing_factory_d3d_unittest.cc
+@@ -965,7 +965,7 @@ void SharedImageBackingFactoryD3DTest::RunCreateSharedImageFromHandleTest(
+   desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+   desc.CPUAccessFlags = 0;
+   desc.MiscFlags =
+-      D3D11_RESOURCE_MISC_SHARED_NTHANDLE | D3D11_RESOURCE_MISC_SHARED;
++      D3D11_RESOURCE_MISC_SHARED;
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+   HRESULT hr = d3d11_device->CreateTexture2D(&desc, nullptr, &d3d11_texture);
+   ASSERT_EQ(hr, S_OK);
+@@ -1310,8 +1310,7 @@ SharedImageBackingFactoryD3DTest::CreateVideoImages(const gfx::Size& size,
+   CD3D11_TEXTURE2D_DESC desc(DXGI_FORMAT_NV12, size.width(), size.height(), 1,
+                              1, D3D11_BIND_SHADER_RESOURCE);
+   if (use_shared_handle) {
+-    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-                     D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
++    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+   }
+ 
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+diff --git gpu/config/gpu_info_collector.cc gpu/config/gpu_info_collector.cc
+index b0c51a19fd5ba..5ee07d17cca84 100644
+--- gpu/config/gpu_info_collector.cc
++++ gpu/config/gpu_info_collector.cc
+@@ -578,8 +578,8 @@ bool CollectGpuExtraInfo(gfx::GpuExtraInfo* gpu_extra_info,
+           QueryEGLStringi(display, EGL_FEATURE_BUG_ANGLE, i);
+       gpu_extra_info->angle_features[i].status =
+           QueryEGLStringi(display, EGL_FEATURE_STATUS_ANGLE, i);
+-      gpu_extra_info->angle_features[i].condition =
+-          QueryEGLStringi(display, EGL_FEATURE_CONDITION_ANGLE, i);
++      //gpu_extra_info->angle_features[i].condition =
++          //QueryEGLStringi(display, EGL_FEATURE_CONDITION_ANGLE, i);
+     }
+   }
+ 
+diff --git gpu/ipc/common/dxgi_helpers.cc gpu/ipc/common/dxgi_helpers.cc
+index e142cb1d2f003..dae2c9fde3bb9 100644
+--- gpu/ipc/common/dxgi_helpers.cc
++++ gpu/ipc/common/dxgi_helpers.cc
+@@ -67,7 +67,7 @@ DXGIScopedReleaseKeyedMutex::~DXGIScopedReleaseKeyedMutex() {
+ }
+ 
+ bool CopyDXGIBufferToShMem(
+-    HANDLE dxgi_handle,
++    uint64_t dxgi_handle,
+     base::span<uint8_t> shared_memory,
+     ID3D11Device* d3d11_device,
+     Microsoft::WRL::ComPtr<ID3D11Texture2D>* staging_texture) {
+@@ -84,7 +84,7 @@ bool CopyDXGIBufferToShMem(
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> texture;
+ 
+   // Open texture on device using shared handle
+-  hr = device1->OpenSharedResource1(dxgi_handle, IID_PPV_ARGS(&texture));
++  hr = d3d11_device->OpenSharedResource(HANDLE(dxgi_handle), IID_PPV_ARGS(&texture));
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "Failed to open shared texture. hr=" << std::hex << hr;
+     return false;
+diff --git gpu/ipc/common/dxgi_helpers.h gpu/ipc/common/dxgi_helpers.h
+index 4adb9293957b3..f5e44e6895ae3 100644
+--- gpu/ipc/common/dxgi_helpers.h
++++ gpu/ipc/common/dxgi_helpers.h
+@@ -60,7 +60,7 @@ class GPU_EXPORT DXGIScopedReleaseKeyedMutex {
+ // a staging texture. The texture may be recreated if it has wrong size or
+ // format. Returns true if succeeded.
+ GPU_EXPORT bool CopyDXGIBufferToShMem(
+-    HANDLE dxgi_handle,
++    uint64_t dxgi_handle,
+     base::span<uint8_t> shared_memory,
+     ID3D11Device* d3d11_device,
+     Microsoft::WRL::ComPtr<ID3D11Texture2D>* staging_texture);
+diff --git gpu/ipc/common/gpu_memory_buffer_impl_dxgi.cc gpu/ipc/common/gpu_memory_buffer_impl_dxgi.cc
+index eb88dfdbba48e..82f816903bf74 100644
+--- gpu/ipc/common/gpu_memory_buffer_impl_dxgi.cc
++++ gpu/ipc/common/gpu_memory_buffer_impl_dxgi.cc
+@@ -32,7 +32,7 @@ GpuMemoryBufferImplDXGI::CreateFromHandle(
+     GpuMemoryBufferManager* gpu_memory_buffer_manager,
+     scoped_refptr<base::UnsafeSharedMemoryPool> pool,
+     base::span<uint8_t> premapped_memory) {
+-  DCHECK(handle.dxgi_handle.IsValid());
++  //DCHECK(handle.dxgi_handle.IsValid());
+   DCHECK(handle.dxgi_token.has_value());
+   return base::WrapUnique(new GpuMemoryBufferImplDXGI(
+       handle.id, size, format, std::move(callback),
+@@ -67,26 +67,25 @@ base::OnceClosure GpuMemoryBufferImplDXGI::AllocateForTesting(
+       D3D11_USAGE_DEFAULT,
+       D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
+       0,
+-      D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-          D3D11_RESOURCE_MISC_SHARED};
++      D3D11_RESOURCE_MISC_SHARED};
+ 
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+ 
+   HRESULT hr = d3d11_device->CreateTexture2D(&desc, nullptr, &d3d11_texture);
+   DCHECK(SUCCEEDED(hr));
+ 
+-  Microsoft::WRL::ComPtr<IDXGIResource1> dxgi_resource;
++  Microsoft::WRL::ComPtr<IDXGIResource> dxgi_resource;
+   hr = d3d11_texture.As(&dxgi_resource);
+   DCHECK(SUCCEEDED(hr));
+ 
+   HANDLE texture_handle;
+-  hr = dxgi_resource->CreateSharedHandle(
+-      nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr,
++  hr = dxgi_resource->GetSharedHandle(
++      //nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr,
+       &texture_handle);
+   DCHECK(SUCCEEDED(hr));
+ 
+   gfx::GpuMemoryBufferId kBufferId(1);
+-  handle->dxgi_handle.Set(texture_handle);
++  handle->dxgi_handle = uint64_t(texture_handle);
+   handle->type = gfx::DXGI_SHARED_HANDLE;
+   handle->id = kBufferId;
+   return base::DoNothing();
+@@ -167,21 +166,23 @@ gfx::GpuMemoryBufferHandle GpuMemoryBufferImplDXGI::CloneHandle() const {
+   handle.id = id_;
+   handle.offset = 0;
+   handle.stride = stride(0);
+-  base::ProcessHandle process = ::GetCurrentProcess();
++  //base::ProcessHandle process = ::GetCurrentProcess();
++  /*
+   HANDLE duplicated_handle;
+   BOOL result =
+       ::DuplicateHandle(process, dxgi_handle_.Get(), process,
+                         &duplicated_handle, 0, FALSE, DUPLICATE_SAME_ACCESS);
+   if (!result)
+     DPLOG(ERROR) << "Failed to duplicate DXGI resource handle.";
+-  handle.dxgi_handle.Set(duplicated_handle);
++  */
++  handle.dxgi_handle = dxgi_handle_;
+   handle.dxgi_token = dxgi_token_;
+ 
+   return handle;
+ }
+ 
+ HANDLE GpuMemoryBufferImplDXGI::GetHandle() const {
+-  return dxgi_handle_.Get();
++  return (HANDLE)dxgi_handle_;
+ }
+ 
+ GpuMemoryBufferImplDXGI::GpuMemoryBufferImplDXGI(
+@@ -189,7 +190,7 @@ GpuMemoryBufferImplDXGI::GpuMemoryBufferImplDXGI(
+     const gfx::Size& size,
+     gfx::BufferFormat format,
+     DestructionCallback callback,
+-    base::win::ScopedHandle dxgi_handle,
++    uint64_t dxgi_handle,
+     gfx::DXGIHandleToken dxgi_token,
+     gpu::GpuMemoryBufferManager* gpu_memory_buffer_manager,
+     scoped_refptr<base::UnsafeSharedMemoryPool> pool,
+diff --git gpu/ipc/common/gpu_memory_buffer_impl_dxgi.h gpu/ipc/common/gpu_memory_buffer_impl_dxgi.h
+index 32159783a2b96..0dcea6cc28e71 100644
+--- gpu/ipc/common/gpu_memory_buffer_impl_dxgi.h
++++ gpu/ipc/common/gpu_memory_buffer_impl_dxgi.h
+@@ -64,13 +64,13 @@ class GPU_EXPORT GpuMemoryBufferImplDXGI : public GpuMemoryBufferImpl {
+                           const gfx::Size& size,
+                           gfx::BufferFormat format,
+                           DestructionCallback callback,
+-                          base::win::ScopedHandle dxgi_handle,
++                          uint64_t dxgi_handle,
+                           gfx::DXGIHandleToken dxgi_token,
+                           GpuMemoryBufferManager* gpu_memory_buffer_manager,
+                           scoped_refptr<base::UnsafeSharedMemoryPool> pool,
+                           base::span<uint8_t> premapped_memory);
+ 
+-  base::win::ScopedHandle dxgi_handle_;
++  uint64_t dxgi_handle_;
+   gfx::DXGIHandleToken dxgi_token_;
+   raw_ptr<GpuMemoryBufferManager> gpu_memory_buffer_manager_;
+ 
+diff --git gpu/ipc/service/gpu_memory_buffer_factory_dxgi.cc gpu/ipc/service/gpu_memory_buffer_factory_dxgi.cc
+index 4d47b62a4f2c0..cab06681192d5 100644
+--- gpu/ipc/service/gpu_memory_buffer_factory_dxgi.cc
++++ gpu/ipc/service/gpu_memory_buffer_factory_dxgi.cc
+@@ -27,6 +27,8 @@ GpuMemoryBufferFactoryDXGI::~GpuMemoryBufferFactoryDXGI() = default;
+ Microsoft::WRL::ComPtr<ID3D11Device>
+ GpuMemoryBufferFactoryDXGI::GetOrCreateD3D11Device() {
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++  return gl::QueryD3D11DeviceObjectFromANGLE();
++#if 0
+   if (!d3d11_device_) {
+     // Use same adapter as ANGLE device.
+     auto angle_d3d11_device = gl::QueryD3D11DeviceObjectFromANGLE();
+@@ -80,6 +82,7 @@ GpuMemoryBufferFactoryDXGI::GetOrCreateD3D11Device() {
+   }
+   DCHECK(d3d11_device_);
+   return d3d11_device_;
++#endif
+ }
+ 
+ gfx::GpuMemoryBufferHandle GpuMemoryBufferFactoryDXGI::CreateGpuMemoryBuffer(
+@@ -129,25 +132,24 @@ gfx::GpuMemoryBufferHandle GpuMemoryBufferFactoryDXGI::CreateGpuMemoryBuffer(
+       D3D11_USAGE_DEFAULT,
+       D3D11_BIND_SHADER_RESOURCE,
+       0,
+-      D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-          D3D11_RESOURCE_MISC_SHARED};
++      D3D11_RESOURCE_MISC_SHARED};
+ 
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+ 
+   if (FAILED(d3d11_device->CreateTexture2D(&desc, nullptr, &d3d11_texture)))
+     return handle;
+ 
+-  Microsoft::WRL::ComPtr<IDXGIResource1> dxgi_resource;
++  Microsoft::WRL::ComPtr<IDXGIResource> dxgi_resource;
+   if (FAILED(d3d11_texture.As(&dxgi_resource)))
+     return handle;
+ 
+   HANDLE texture_handle;
+-  if (FAILED(dxgi_resource->CreateSharedHandle(
+-          nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+-          nullptr, &texture_handle)))
++  if (FAILED(dxgi_resource->GetSharedHandle(
++          //nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
++          /*nullptr, */&texture_handle)))
+     return handle;
+ 
+-  handle.dxgi_handle.Set(texture_handle);
++  handle.dxgi_handle = uint64_t(texture_handle);
+   handle.dxgi_token = gfx::DXGIHandleToken();
+   handle.type = gfx::DXGI_SHARED_HANDLE;
+   handle.id = id;
+@@ -172,7 +174,7 @@ bool GpuMemoryBufferFactoryDXGI::FillSharedMemoryRegionWithBufferContents(
+   if (!mapping.IsValid())
+     return false;
+ 
+-  return CopyDXGIBufferToShMem(buffer_handle.dxgi_handle.Get(),
++  return CopyDXGIBufferToShMem(buffer_handle.dxgi_handle,
+                                mapping.GetMemoryAsSpan<uint8_t>(),
+                                d3d11_device.Get(), &staging_texture_);
+ }
+diff --git media/capture/video/win/gpu_memory_buffer_tracker.cc media/capture/video/win/gpu_memory_buffer_tracker.cc
+index 4e92d302235e5..7fdfe69fbd390 100644
+--- media/capture/video/win/gpu_memory_buffer_tracker.cc
++++ media/capture/video/win/gpu_memory_buffer_tracker.cc
+@@ -21,7 +21,7 @@ namespace media {
+ 
+ namespace {
+ 
+-base::win::ScopedHandle CreateNV12Texture(ID3D11Device* d3d11_device,
++uint64_t CreateNV12Texture(ID3D11Device* d3d11_device,
+                                           const gfx::Size& size) {
+   const DXGI_FORMAT dxgi_format = DXGI_FORMAT_NV12;
+   D3D11_TEXTURE2D_DESC desc = {
+@@ -34,8 +34,7 @@ base::win::ScopedHandle CreateNV12Texture(ID3D11Device* d3d11_device,
+       .Usage = D3D11_USAGE_DEFAULT,
+       .BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
+       .CPUAccessFlags = 0,
+-      .MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-                   D3D11_RESOURCE_MISC_SHARED};
++      .MiscFlags = D3D11_RESOURCE_MISC_SHARED};
+ 
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture;
+ 
+@@ -43,29 +42,29 @@ base::win::ScopedHandle CreateNV12Texture(ID3D11Device* d3d11_device,
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "Failed to create D3D11 texture: "
+                 << logging::SystemErrorCodeToString(hr);
+-    return base::win::ScopedHandle();
++    return uint64_t(0);
+   }
+   hr = SetDebugName(d3d11_texture.Get(), "Camera_MemoryBufferTracker");
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "Failed to label D3D11 texture: "
+                 << logging::SystemErrorCodeToString(hr);
+-    return base::win::ScopedHandle();
++    return uint64_t(0);
+   }
+ 
+-  Microsoft::WRL::ComPtr<IDXGIResource1> dxgi_resource;
++  Microsoft::WRL::ComPtr<IDXGIResource> dxgi_resource;
+   hr = d3d11_texture.As(&dxgi_resource);
+   CHECK(SUCCEEDED(hr));
+ 
+   HANDLE texture_handle;
+-  hr = dxgi_resource->CreateSharedHandle(
+-      nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr,
++  hr = dxgi_resource->GetSharedHandle(
++      //nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE, nullptr,
+       &texture_handle);
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "Failed to create shared D3D11 texture handle: "
+                 << logging::SystemErrorCodeToString(hr);
+-    return base::win::ScopedHandle();
++    return uint64_t(0);
+   }
+-  return base::win::ScopedHandle(texture_handle);
++  return uint64_t(texture_handle);
+ }
+ 
+ }  // namespace
+@@ -97,10 +96,10 @@ bool GpuMemoryBufferTracker::CreateBufferInternal() {
+       CreateNV12Texture(d3d_device_.Get(), buffer_size_);
+   buffer_handle.dxgi_token = gfx::DXGIHandleToken();
+ 
+-  if (!buffer_handle.dxgi_handle.IsValid()) {
++  /*if (!buffer_handle.dxgi_handle.IsValid()) {
+     LOG(ERROR) << "Failed to create NV12 texture";
+     return false;
+-  }
++  }*/
+ 
+   buffer_ = gpu::GpuMemoryBufferImplDXGI::CreateFromHandle(
+       std::move(buffer_handle), buffer_size_,
+@@ -154,7 +153,7 @@ GpuMemoryBufferTracker::DuplicateAsUnsafeRegion() {
+   CHECK(region_.IsValid());
+   CHECK(mapping_.IsValid());
+ 
+-  if (!gpu::CopyDXGIBufferToShMem(buffer_->GetHandle(),
++  if (!gpu::CopyDXGIBufferToShMem(uint64_t(buffer_->GetHandle()),
+                                   mapping_.GetMemoryAsSpan<uint8_t>(),
+                                   d3d_device_.Get(), &staging_texture_)) {
+     DLOG(ERROR) << "Couldn't copy DXGI buffer to shmem";
+diff --git media/capture/video/win/video_capture_device_mf_win.cc media/capture/video/win/video_capture_device_mf_win.cc
+index 3fbcc3bdb63ff..2a5b35d0d925c 100644
+--- media/capture/video/win/video_capture_device_mf_win.cc
++++ media/capture/video/win/video_capture_device_mf_win.cc
+@@ -566,7 +566,7 @@ void GetTextureSizeAndFormat(ID3D11Texture2D* texture,
+ }
+ 
+ HRESULT CopyTextureToGpuMemoryBuffer(ID3D11Texture2D* texture,
+-                                     HANDLE dxgi_handle) {
++                                     uint64_t dxgi_handle) {
+   Microsoft::WRL::ComPtr<ID3D11Device> texture_device;
+   texture->GetDevice(&texture_device);
+ 
+@@ -580,7 +580,7 @@ HRESULT CopyTextureToGpuMemoryBuffer(ID3D11Texture2D* texture,
+ 
+   // Open shared resource from GpuMemoryBuffer on source texture D3D11 device
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> target_texture;
+-  hr = device1->OpenSharedResource1(dxgi_handle, IID_PPV_ARGS(&target_texture));
++  hr = texture_device->OpenSharedResource(HANDLE(dxgi_handle), IID_PPV_ARGS(&target_texture));
+   if (FAILED(hr)) {
+     DLOG(ERROR) << "Failed to open shared camera target texture: "
+                 << logging::SystemErrorCodeToString(hr);
+@@ -1600,12 +1600,12 @@ HRESULT VideoCaptureDeviceMFWin::DeliverTextureToClient(
+   }
+ 
+   auto gmb_handle = capture_buffer.handle_provider->GetGpuMemoryBufferHandle();
+-  if (!gmb_handle.dxgi_handle.IsValid()) {
++/*  if (!gmb_handle.dxgi_handle.IsValid()) {
+     // If the device is removed and GMB tracker fails to recreate it,
+     // an empty gmb handle may be returned here.
+     return MF_E_UNEXPECTED;
+-  }
+-  hr = CopyTextureToGpuMemoryBuffer(texture, gmb_handle.dxgi_handle.Get());
++  }*/
++  hr = CopyTextureToGpuMemoryBuffer(texture, gmb_handle.dxgi_handle);
+ 
+   if (FAILED(hr)) {
+     LOG(ERROR) << "Failed to copy camera device texture to output texture: "
+diff --git media/gpu/windows/d3d11_decoder_configurator.cc media/gpu/windows/d3d11_decoder_configurator.cc
+index 5967559120ef9..b5e1c6eda0996 100644
+--- media/gpu/windows/d3d11_decoder_configurator.cc
++++ media/gpu/windows/d3d11_decoder_configurator.cc
+@@ -113,8 +113,7 @@ D3D11DecoderConfigurator::CreateOutputTexture(ComD3D11Device device,
+     // shouldn't be encrypted.
+     DCHECK(!supports_swap_chain_);
+     DCHECK(!is_encrypted_);
+-    output_texture_desc_.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-                                     D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
++    output_texture_desc_.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+   } else if (supports_swap_chain_) {
+     // Decode swap chains do not support shared resources.
+     // TODO(sunnyps): Find a workaround for when the decoder moves to its own
+diff --git media/gpu/windows/d3d11_texture_selector.cc media/gpu/windows/d3d11_texture_selector.cc
+index ac5600448769e..c68a7a16fa9ff 100644
+--- media/gpu/windows/d3d11_texture_selector.cc
++++ media/gpu/windows/d3d11_texture_selector.cc
+@@ -201,8 +201,7 @@ std::unique_ptr<Texture2DWrapper> CopyTextureSelector::CreateTextureWrapper(
+   texture_desc.Width = size.width();
+   texture_desc.Height = size.height();
+   if (DoesSharedImageUseSharedHandle()) {
+-    texture_desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-                             D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
++    texture_desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+   }
+ 
+   ComD3D11Texture2D out_texture;
+diff --git media/gpu/windows/d3d11_texture_wrapper.cc media/gpu/windows/d3d11_texture_wrapper.cc
+index 59c3e39edafee..dde107c9649ef 100644
+--- media/gpu/windows/d3d11_texture_wrapper.cc
++++ media/gpu/windows/d3d11_texture_wrapper.cc
+@@ -214,7 +214,7 @@ DefaultTexture2DWrapper::GpuResources::GpuResources(
+     texture->GetDesc(&desc);
+     // Create shared handle for shareable output texture.
+     if (desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE) {
+-      Microsoft::WRL::ComPtr<IDXGIResource1> dxgi_resource;
++      Microsoft::WRL::ComPtr<IDXGIResource> dxgi_resource;
+       HRESULT hr = texture.As(&dxgi_resource);
+       if (FAILED(hr)) {
+         DLOG(ERROR) << "QueryInterface for IDXGIResource failed with error "
+@@ -224,10 +224,10 @@ DefaultTexture2DWrapper::GpuResources::GpuResources(
+         return;
+       }
+ 
+-      HANDLE shared_handle = nullptr;
+-      hr = dxgi_resource->CreateSharedHandle(
+-          nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+-          nullptr, &shared_handle);
++      HANDLE shared_handle = 0;
++      hr = dxgi_resource->GetSharedHandle(
++          //nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
++          /*nullptr, */&shared_handle);
+       if (FAILED(hr)) {
+         DLOG(ERROR) << "CreateSharedHandle failed with error " << std::hex
+                     << hr;
+@@ -239,7 +239,7 @@ DefaultTexture2DWrapper::GpuResources::GpuResources(
+       dxgi_shared_handle_state =
+           helper_->GetDXGISharedHandleManager()
+               ->CreateAnonymousSharedHandleState(
+-                  base::win::ScopedHandle(shared_handle), texture);
++                  uint64_t(shared_handle), texture);
+     }
+   }
+ 
+diff --git media/gpu/windows/media_foundation_video_encode_accelerator_win.cc media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
+index f7b7aaf10ab58..36c70ddfe12b3 100644
+--- media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
++++ media/gpu/windows/media_foundation_video_encode_accelerator_win.cc
+@@ -1136,8 +1136,8 @@ HRESULT MediaFoundationVideoEncodeAccelerator::PopulateInputSampleBufferGpu(
+   RETURN_ON_HR_FAILURE(hr, "Failed to query ID3D11Device1", hr);
+ 
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> input_texture;
+-  hr = device1->OpenSharedResource1(buffer_handle.dxgi_handle.Get(),
+-                                    IID_PPV_ARGS(&input_texture));
++  hr = d3d_device->OpenSharedResource(HANDLE(buffer_handle.dxgi_handle),
++                                   IID_PPV_ARGS(&input_texture));
+   RETURN_ON_HR_FAILURE(hr, "Failed to open shared GMB D3D texture", hr);
+ 
+   // Check if we need to scale the input texture
+diff --git media/renderers/win/media_foundation_texture_pool.cc media/renderers/win/media_foundation_texture_pool.cc
+index 0c3ad4dda7aa0..50c7e17dc0fbb 100644
+--- media/renderers/win/media_foundation_texture_pool.cc
++++ media/renderers/win/media_foundation_texture_pool.cc
+@@ -56,8 +56,7 @@ HRESULT MediaFoundationTexturePool::Initialize(
+       D3D11_USAGE_DEFAULT,
+       D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE,
+       0,
+-      D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-          D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX};
++      D3D11_RESOURCE_MISC_SHARED};
+ 
+   std::vector<MediaFoundationFrameInfo> frame_infos;
+   bool callback_is_valid = !frame_pool_cb.is_null();
+@@ -78,23 +77,20 @@ HRESULT MediaFoundationTexturePool::Initialize(
+         device->CreateTexture2D(&desc, nullptr, &d3d11_video_frame));
+     SetDebugName(d3d11_video_frame.Get(), "Media_MFFrameServerMode_Pool");
+ 
+-    ComPtr<IDXGIResource1> d3d11_video_frame_resource;
++    ComPtr<IDXGIResource> d3d11_video_frame_resource;
+     RETURN_IF_FAILED(d3d11_video_frame.As(&d3d11_video_frame_resource));
+ 
+     HANDLE shared_texture_handle;
+-    RETURN_IF_FAILED(d3d11_video_frame_resource->CreateSharedHandle(
+-        nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+-        nullptr, &shared_texture_handle));
++    RETURN_IF_FAILED(d3d11_video_frame_resource->GetSharedHandle(
++        //nullptr, DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
++        /*nullptr, */&shared_texture_handle));
+ 
+-    base::win::ScopedHandle scoped_shared_texture_handle;
+-    scoped_shared_texture_handle.Set(shared_texture_handle);
+-    shared_texture_handle = nullptr;
+     texture_pool_[texture_token].texture_ = std::move(d3d11_video_frame);
+     texture_pool_[texture_token].texture_in_use_ = false;
+ 
+     if (callback_is_valid) {
+       MediaFoundationFrameInfo frame_info;
+-      frame_info.dxgi_handle = std::move(scoped_shared_texture_handle);
++      frame_info.dxgi_handle = uint64_t(shared_texture_handle);
+       frame_info.token = texture_token;
+       frame_infos.emplace_back(std::move(frame_info));
+     }
+diff --git media/renderers/win/media_foundation_texture_pool.h media/renderers/win/media_foundation_texture_pool.h
+index fe0105554af6e..ff505efe97f9e 100644
+--- media/renderers/win/media_foundation_texture_pool.h
++++ media/renderers/win/media_foundation_texture_pool.h
+@@ -22,7 +22,7 @@ struct MEDIA_EXPORT MediaFoundationFrameInfo {
+   MediaFoundationFrameInfo();
+   ~MediaFoundationFrameInfo();
+   MediaFoundationFrameInfo(MediaFoundationFrameInfo&& other);
+-  base::win::ScopedHandle dxgi_handle;
++  uint64_t dxgi_handle;
+   base::UnguessableToken token;
+ };
+ 
+diff --git third_party/blink/renderer/platform/graphics/gpu/xr_frame_transport.cc third_party/blink/renderer/platform/graphics/gpu/xr_frame_transport.cc
+index f8b203fee866d..53174fa93d02b 100644
+--- third_party/blink/renderer/platform/graphics/gpu/xr_frame_transport.cc
++++ third_party/blink/renderer/platform/graphics/gpu/xr_frame_transport.cc
+@@ -139,10 +139,10 @@ void XRFrameTransport::FrameSubmit(
+     // We decompose the cloned handle, and use it to create a
+     // mojo::PlatformHandle which will own cleanup of the handle, and will be
+     // passed over IPC.
+-    gfx::GpuMemoryBufferHandle gpu_handle = gpu_memory_buffer->CloneHandle();
+-    vr_presentation_provider->SubmitFrameWithTextureHandle(
++    //gfx::GpuMemoryBufferHandle gpu_handle = gpu_memory_buffer->CloneHandle();
++    /*vr_presentation_provider->SubmitFrameWithTextureHandle(
+         vr_frame_id, mojo::PlatformHandle(std::move(gpu_handle.dxgi_handle)),
+-        sync_token);
++        sync_token);*/
+ #else
+     NOTIMPLEMENTED();
+ #endif
+diff --git ui/gfx/gpu_memory_buffer.cc ui/gfx/gpu_memory_buffer.cc
+index a49e5bb559f22..98656216292df 100644
+--- ui/gfx/gpu_memory_buffer.cc
++++ ui/gfx/gpu_memory_buffer.cc
+@@ -15,19 +15,6 @@
+ 
+ namespace gfx {
+ 
+-#if BUILDFLAG(IS_WIN)
+-namespace {
+-base::win::ScopedHandle CloneDXGIHandle(HANDLE handle) {
+-  HANDLE target_handle = nullptr;
+-  if (!::DuplicateHandle(GetCurrentProcess(), handle, GetCurrentProcess(),
+-                         &target_handle, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
+-    DVLOG(1) << "Error duplicating GMB DXGI handle. error=" << GetLastError();
+-  }
+-  return base::win::ScopedHandle(target_handle);
+-}
+-}  // namespace
+-#endif
+-
+ GpuMemoryBufferHandle::GpuMemoryBufferHandle() = default;
+ 
+ #if BUILDFLAG(IS_ANDROID)
+@@ -59,7 +46,7 @@ GpuMemoryBufferHandle GpuMemoryBufferHandle::Clone() const {
+ #elif BUILDFLAG(IS_MAC)
+   handle.io_surface = io_surface;
+ #elif BUILDFLAG(IS_WIN)
+-  handle.dxgi_handle = CloneDXGIHandle(dxgi_handle.Get());
++  handle.dxgi_handle = dxgi_handle;
+   handle.dxgi_token = dxgi_token;
+ #elif BUILDFLAG(IS_ANDROID)
+   NOTIMPLEMENTED();
+diff --git ui/gfx/gpu_memory_buffer.h ui/gfx/gpu_memory_buffer.h
+index 7bb66fa2ade18..9b661572e20a5 100644
+--- ui/gfx/gpu_memory_buffer.h
++++ ui/gfx/gpu_memory_buffer.h
+@@ -83,7 +83,7 @@ struct GFX_EXPORT GpuMemoryBufferHandle {
+ #elif BUILDFLAG(IS_MAC)
+   ScopedIOSurface io_surface;
+ #elif BUILDFLAG(IS_WIN)
+-  base::win::ScopedHandle dxgi_handle;
++  uint64_t dxgi_handle = 0;
+   absl::optional<DXGIHandleToken> dxgi_token;
+ #elif BUILDFLAG(IS_ANDROID)
+   base::android::ScopedHardwareBufferHandle android_hardware_buffer;
+diff --git ui/gfx/mojom/buffer_types_mojom_traits.cc ui/gfx/mojom/buffer_types_mojom_traits.cc
+index 154c2ddeaa9ea..0fad11885c0ef 100644
+--- ui/gfx/mojom/buffer_types_mojom_traits.cc
++++ ui/gfx/mojom/buffer_types_mojom_traits.cc
+@@ -52,11 +52,11 @@ gfx::mojom::GpuMemoryBufferPlatformHandlePtr StructTraits<
+     }
+     case gfx::DXGI_SHARED_HANDLE:
+ #if BUILDFLAG(IS_WIN)
+-      DCHECK(handle.dxgi_handle.IsValid());
++      //DCHECK(handle.dxgi_handle.IsValid());
+       DCHECK(handle.dxgi_token.has_value());
+       return gfx::mojom::GpuMemoryBufferPlatformHandle::NewDxgiHandle(
+           gfx::mojom::DXGIHandle::New(
+-              mojo::PlatformHandle(std::move(handle.dxgi_handle)),
++              std::move(handle.dxgi_handle),
+               std::move(handle.dxgi_token.value()), std::move(handle.region)));
+ #else
+       break;
+@@ -141,7 +141,7 @@ bool StructTraits<gfx::mojom::GpuMemoryBufferHandleDataView,
+     case gfx::mojom::GpuMemoryBufferPlatformHandleDataView::Tag::kDxgiHandle: {
+       out->type = gfx::DXGI_SHARED_HANDLE;
+       auto dxgi_handle = std::move(platform_handle->get_dxgi_handle());
+-      out->dxgi_handle = dxgi_handle->buffer_handle.TakeHandle();
++      out->dxgi_handle = dxgi_handle->buffer_handle;
+       out->dxgi_token = std::move(dxgi_handle->token);
+       out->region = std::move(dxgi_handle->shared_memory_handle);
+       return true;
+diff --git ui/gfx/mojom/native_handle_types.mojom ui/gfx/mojom/native_handle_types.mojom
+index d8079b3810423..1609ce88c8463 100644
+--- ui/gfx/mojom/native_handle_types.mojom
++++ ui/gfx/mojom/native_handle_types.mojom
+@@ -59,7 +59,7 @@ struct DXGIHandleToken {
+ [EnableIf=is_win]
+ struct DXGIHandle {
+   // The actual buffer windows handle.
+-  handle<platform> buffer_handle;
++  uint64 buffer_handle;
+ 
+   // A unique identifier for the texture corresponding to this GMB handle. This
+   // is needed because there's no other way to uniquely identify the underlying
+diff --git ui/gl/direct_composition_surface_win_unittest.cc ui/gl/direct_composition_surface_win_unittest.cc
+index 741c3dd30425f..446074697fb05 100644
+--- ui/gl/direct_composition_surface_win_unittest.cc
++++ ui/gl/direct_composition_surface_win_unittest.cc
+@@ -95,8 +95,7 @@ Microsoft::WRL::ComPtr<ID3D11Texture2D> CreateNV12Texture(
+   desc.SampleDesc.Count = 1;
+   desc.BindFlags = 0;
+   if (shared) {
+-    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED |
+-                     D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
++    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+   }
+ 
+   std::vector<char> image_data(size.width() * size.height() * 3 / 2);
+diff --git ui/gl/gl_image_dxgi.cc ui/gl/gl_image_dxgi.cc
+index 6f05585e228ca..8c01effd85b0a 100644
+--- ui/gl/gl_image_dxgi.cc
++++ ui/gl/gl_image_dxgi.cc
+@@ -144,7 +144,7 @@ GLImageDXGI::BindOrCopy GLImageDXGI::ShouldBindOrCopy() {
+ }
+ 
+ bool GLImageDXGI::BindTexImage(unsigned target) {
+-  if (!handle_.Get())
++  if (!handle_)
+     return true;
+ 
+   DCHECK(texture_);
+@@ -180,7 +180,7 @@ bool GLImageDXGI::CopyTexSubImage(unsigned target,
+ void GLImageDXGI::Flush() {}
+ 
+ unsigned GLImageDXGI::GetInternalFormat() {
+-  if (!handle_.Get())
++  if (!handle_)
+     return GL_BGRA_EXT;
+   else
+     return HasAlpha(buffer_format_) ? GL_RGBA : GL_RGB;
+@@ -203,7 +203,7 @@ void GLImageDXGI::OnMemoryDump(base::trace_event::ProcessMemoryDump* pmd,
+                                const std::string& dump_name) {}
+ 
+ void GLImageDXGI::ReleaseTexImage(unsigned target) {
+-  if (!handle_.Get())
++  if (!handle_)
+     return;
+ 
+   DCHECK(texture_);
+@@ -223,7 +223,7 @@ void GLImageDXGI::ReleaseTexImage(unsigned target) {
+                      surface_, EGL_BACK_BUFFER);
+ }
+ 
+-bool GLImageDXGI::InitializeHandle(base::win::ScopedHandle handle,
++bool GLImageDXGI::InitializeHandle(uint64_t handle,
+                                    uint32_t level,
+                                    gfx::BufferFormat format) {
+   level_ = level;
+@@ -233,12 +233,8 @@ bool GLImageDXGI::InitializeHandle(base::win::ScopedHandle handle,
+   if (!d3d11_device)
+     return false;
+ 
+-  Microsoft::WRL::ComPtr<ID3D11Device1> d3d11_device1;
+-  if (FAILED(d3d11_device.As(&d3d11_device1)))
+-    return false;
+-
+-  if (FAILED(d3d11_device1->OpenSharedResource1(handle.Get(),
+-                                                IID_PPV_ARGS(&staging_)))) {
++  if (FAILED(d3d11_device->OpenSharedResource(HANDLE(handle),
++                                               IID_PPV_ARGS(&staging_)))) {
+     return false;
+   }
+   D3D11_TEXTURE2D_DESC desc;
+@@ -249,7 +245,7 @@ bool GLImageDXGI::InitializeHandle(base::win::ScopedHandle handle,
+   desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+   desc.MiscFlags = 0;
+ 
+-  if (FAILED(d3d11_device1->CreateTexture2D(&desc, nullptr, &texture_))) {
++  if (FAILED(d3d11_device->CreateTexture2D(&desc, nullptr, &texture_))) {
+      return false;
+   }
+ 
+@@ -265,7 +261,7 @@ void GLImageDXGI::SetTexture(
+ }
+ 
+ GLImageDXGI::~GLImageDXGI() {
+-  if (handle_.Get()) {
++  if (handle_) {
+     if (surface_ != EGL_NO_SURFACE) {
+       eglDestroySurface(
+           gl::GLSurfaceEGL::GetGLDisplayEGL()->GetHardwareDisplay(), surface_);
+diff --git ui/gl/gl_image_dxgi.h ui/gl/gl_image_dxgi.h
+index 91596e4e3c412..010fb9835d3fb 100644
+--- ui/gl/gl_image_dxgi.h
++++ ui/gl/gl_image_dxgi.h
+@@ -47,7 +47,7 @@ class GL_EXPORT GLImageDXGI : public GLImage {
+   size_t level() const { return level_; }
+   Microsoft::WRL::ComPtr<ID3D11Texture2D> texture() { return texture_; }
+ 
+-  bool InitializeHandle(base::win::ScopedHandle handle,
++  bool InitializeHandle(uint64_t handle,
+                         uint32_t level,
+                         gfx::BufferFormat format);
+   void SetTexture(const Microsoft::WRL::ComPtr<ID3D11Texture2D>& texture,
+@@ -57,7 +57,7 @@ class GL_EXPORT GLImageDXGI : public GLImage {
+   ~GLImageDXGI() override;
+ 
+   gfx::BufferFormat buffer_format_ = gfx::BufferFormat::BGRA_8888;
+-  base::win::ScopedHandle handle_;
++  uint64_t handle_;
+   size_t level_ = 0;
+   gfx::Size size_;
+   EGLSurface surface_ = nullptr;
+diff --git ui/gl/gl_image_dxgi_unittest.cc ui/gl/gl_image_dxgi_unittest.cc
+index f388966098b44..7181a7a2a6fbc 100644
+--- ui/gl/gl_image_dxgi_unittest.cc
++++ ui/gl/gl_image_dxgi_unittest.cc
+@@ -35,8 +35,7 @@ class GLImageDXGITestDelegate : public GLImageTestDelegateBase {
+     desc.Usage = D3D11_USAGE_DEFAULT;
+     desc.BindFlags = D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET;
+     desc.CPUAccessFlags = 0;
+-    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+-                     D3D11_RESOURCE_MISC_SHARED;
++    desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED;
+ 
+     std::vector<unsigned char> originalData(size.width() * size.height() * 4);
+     for (int x = 0; x < size.width(); ++x) {
+diff --git ui/gl/swap_chain_presenter.cc ui/gl/swap_chain_presenter.cc
+index 8c17b8e6eca05..45c6e36658246 100644
+--- ui/gl/swap_chain_presenter.cc
++++ ui/gl/swap_chain_presenter.cc
+@@ -725,8 +725,7 @@ bool SwapChainPresenter::TryPresentToDecodeSwapChain(
+     // thread and D3D device.  See https://crbug.com/911847
+     bool is_shared_texture =
+         texture_desc.MiscFlags &
+-        (D3D11_RESOURCE_MISC_SHARED | D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX |
+-         D3D11_RESOURCE_MISC_SHARED_NTHANDLE);
++        (D3D11_RESOURCE_MISC_SHARED);
+ 
+     // DXVA decoder (or rather MFT) sometimes gives texture arrays with one
+     // element, which constitutes most of decode swap chain creation failures.

--- a/patch/patches/path_getter.patch
+++ b/patch/patches/path_getter.patch
@@ -1,0 +1,26 @@
+diff --git third_party/blink/renderer/core/fileapi/file.h third_party/blink/renderer/core/fileapi/file.h
+index 72d6b7e109779..e12c4acfd87f1 100644
+--- third_party/blink/renderer/core/fileapi/file.h
++++ third_party/blink/renderer/core/fileapi/file.h
+@@ -212,6 +212,9 @@ class CORE_EXPORT File final : public Blob {
+   }
+   const String& name() const { return name_; }
+ 
++  // Getter for the path IDL attribute.
++  const String& path() const { return GetPath(); }
++
+   // Getter for the lastModified IDL attribute,
+   // http://dev.w3.org/2006/webapi/FileAPI/#file-attrs
+   int64_t lastModified() const;
+diff --git third_party/blink/renderer/core/fileapi/file.idl third_party/blink/renderer/core/fileapi/file.idl
+index 4339a27e87c12..6aebb1ba4f74a 100644
+--- third_party/blink/renderer/core/fileapi/file.idl
++++ third_party/blink/renderer/core/fileapi/file.idl
+@@ -31,6 +31,7 @@
+ ] interface File : Blob {
+     [CallWith=ExecutionContext] constructor(sequence<BlobPart> fileBits, USVString fileName, optional FilePropertyBag options = {});
+     readonly attribute DOMString name;
++    readonly attribute DOMString path;
+     readonly attribute long long lastModified;
+ 
+     // Non-standard APIs

--- a/patch/patches/revert_background.patch
+++ b/patch/patches/revert_background.patch
@@ -1,0 +1,105 @@
+diff --git third_party/blink/renderer/core/paint/background_image_geometry.cc third_party/blink/renderer/core/paint/background_image_geometry.cc
+index c3aad44662720..1f02feeec0283 100644
+--- third_party/blink/renderer/core/paint/background_image_geometry.cc
++++ third_party/blink/renderer/core/paint/background_image_geometry.cc
+@@ -425,13 +425,13 @@ BackgroundImageGeometry::BackgroundImageGeometry(
+     // specified for that element. For all other elements that are effected
+     // by a transform, a value of fixed for the background-attachment property
+     // is treated as if it had a value of scroll.
+-    for (const PaintLayer* layer = box->EnclosingLayer();
+-         layer && !layer->IsRootLayer(); layer = layer->Parent()) {
+-      // Check LayoutObject::HasTransformRelatedProperty() first to exclude
+-      // non-applicable transforms and will-change: transform.
+-      if (layer->GetLayoutObject().HasTransformRelatedProperty() &&
+-          (layer->Transform() ||
+-           layer->GetLayoutObject().StyleRef().HasWillChangeTransformHint())) {
++    for (const LayoutObject* container = box;
++         container && !IsA<LayoutView>(container);
++         container = container->Container()) {
++      // Not using HasTransformRelatedProperty(), to excludes will-change:
++      // transform, etc. Otherwise at least
++      // compositing/backgrounds/fixed-backgrounds.html will fail.
++      if (container->HasTransform()) {
+         has_background_fixed_to_viewport_ = false;
+         break;
+       }
+diff --git third_party/blink/web_tests/compositing/backgrounds/fixed-background-on-descendant.html third_party/blink/web_tests/compositing/backgrounds/fixed-background-on-descendant.html
+index 3fe07e2a4c6bd..9223c24392a7f 100644
+--- third_party/blink/web_tests/compositing/backgrounds/fixed-background-on-descendant.html
++++ third_party/blink/web_tests/compositing/backgrounds/fixed-background-on-descendant.html
+@@ -32,7 +32,7 @@
+     }
+ 
+     .composited {
+-        will-change: opacity;
++        will-change: transform;
+     }
+ </style>
+ <script>
+diff --git third_party/blink/web_tests/compositing/backgrounds/fixed-backgrounds.html third_party/blink/web_tests/compositing/backgrounds/fixed-backgrounds.html
+index 5d1153dbc2573..02689bea7f4a8 100644
+--- third_party/blink/web_tests/compositing/backgrounds/fixed-backgrounds.html
++++ third_party/blink/web_tests/compositing/backgrounds/fixed-backgrounds.html
+@@ -22,7 +22,7 @@
+     }
+ 
+     .composited {
+-        will-change: opacity;
++        will-change: transform;
+     }
+ </style>
+ <script>
+diff --git third_party/blink/web_tests/external/wpt/css/css-transforms/transform-fixed-bg-008.tentative.html third_party/blink/web_tests/external/wpt/css/css-transforms/transform-fixed-bg-008.tentative.html
+deleted file mode 100644
+index d2fc4b6244e04..0000000000000
+--- third_party/blink/web_tests/external/wpt/css/css-transforms/transform-fixed-bg-008.tentative.html
++++ /dev/null
+@@ -1,35 +0,0 @@
+-<!DOCTYPE html>
+-<html>
+-  <head>
+-    <title>CSS Test (Transforms): Fixed Background (will-change: transform)</title>
+-    <link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-rendering">
+-    <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6951">
+-    <meta name="assert" content='"Fixed backgrounds on the root element are
+-    affected by any transform specified for that element. For all other
+-    elements that are effected by a transform (i.e. have a transform applied
+-    to them, or to any of their ancestor elements), a value of fixed for the
+-    background-attachment property is treated as if it had a value of scroll."
+-    This tests that adding will-change: transform to an element with a fixed
+-    background doesn&apos;t change rendering from scroll background.'>
+-    <meta name="flags" content="svg">
+-    <link rel="match" href="transform-fixed-bg-ref.html">
+-    <meta name="fuzzy" content="0-5;0-200">
+-    <style>
+-      body {
+-        margin: 0;
+-      }
+-      div {
+-        background: url(support/transform-triangle-left.svg) fixed;
+-        width: 100px;
+-        height: 100px;
+-        position: relative;
+-        left: 50px;
+-        top: 50px;
+-        will-change: transform;
+-      }
+-    </style>
+-  </head>
+-  <body>
+-    <div></div>
+-  </body>
+-</html>
+diff --git third_party/blink/web_tests/external/wpt/css/cssom-view/add-background-attachment-fixed-during-smooth-scroll.html third_party/blink/web_tests/external/wpt/css/cssom-view/add-background-attachment-fixed-during-smooth-scroll.html
+index 6600c0e0555ce..a031b3715a34b 100644
+--- third_party/blink/web_tests/external/wpt/css/cssom-view/add-background-attachment-fixed-during-smooth-scroll.html
++++ third_party/blink/web_tests/external/wpt/css/cssom-view/add-background-attachment-fixed-during-smooth-scroll.html
+@@ -11,7 +11,7 @@
+   height: 200px;
+   overflow: scroll;
+   background: linear-gradient(green, blue);
+-  will-change: scroll-position;
++  will-change: transform;
+ }
+ #content {
+   width: 7500px;

--- a/patch/patches/revert_geometry.patch
+++ b/patch/patches/revert_geometry.patch
@@ -1,0 +1,526 @@
+diff --git third_party/blink/renderer/core/paint/background_image_geometry.cc third_party/blink/renderer/core/paint/background_image_geometry.cc
+index 1f02feeec0283..1dc05f968c8b7 100644
+--- third_party/blink/renderer/core/paint/background_image_geometry.cc
++++ third_party/blink/renderer/core/paint/background_image_geometry.cc
+@@ -13,14 +13,12 @@
+ #include "third_party/blink/renderer/core/layout/ng/ng_fragmentation_utils.h"
+ #include "third_party/blink/renderer/core/layout/ng/ng_physical_box_fragment.h"
+ #include "third_party/blink/renderer/core/layout/ng/table/layout_ng_table_cell.h"
+-#include "third_party/blink/renderer/core/paint/paint_info.h"
+ #include "third_party/blink/renderer/core/paint/paint_layer.h"
+ #include "third_party/blink/renderer/core/paint/paint_layer_scrollable_area.h"
+ #include "third_party/blink/renderer/core/paint/rounded_border_geometry.h"
+ #include "third_party/blink/renderer/core/style/border_edge.h"
+ #include "third_party/blink/renderer/platform/geometry/layout_rect.h"
+ #include "third_party/blink/renderer/platform/geometry/layout_unit.h"
+-#include "third_party/blink/renderer/platform/graphics/paint/geometry_mapper.h"
+ #include "third_party/blink/renderer/platform/graphics/paint/paint_controller.h"
+ 
+ namespace blink {
+@@ -54,6 +52,25 @@ LayoutUnit ComputeTilePhase(LayoutUnit position, LayoutUnit tile_extent) {
+                      : LayoutUnit();
+ }
+ 
++PhysicalOffset AccumulatedScrollOffsetForFixedBackground(
++    const LayoutBoxModelObject& object,
++    const LayoutBoxModelObject* container) {
++  PhysicalOffset result;
++  if (&object == container)
++    return result;
++
++  LayoutObject::AncestorSkipInfo skip_info(container);
++  for (const LayoutBlock* block = object.ContainingBlock(&skip_info);
++       block && !skip_info.AncestorSkipped();
++       block = block->ContainingBlock(&skip_info)) {
++    if (block->IsScrollContainer())
++      result += block->ScrolledContentOffset();
++    if (block == container)
++      break;
++  }
++  return result;
++}
++
+ }  // anonymous namespace
+ 
+ bool NeedsFullSizeDestination(const FillLayer& fill_layer) {
+@@ -212,7 +229,6 @@ void BackgroundImageGeometry::SetSpaceY(LayoutUnit space,
+ 
+ void BackgroundImageGeometry::UseFixedAttachment(
+     const PhysicalOffset& attachment_point) {
+-  DCHECK(has_background_fixed_to_viewport_);
+   PhysicalOffset fixed_adjustment =
+       attachment_point - unsnapped_dest_rect_.offset;
+   fixed_adjustment.ClampNegativeToZero();
+@@ -312,33 +328,58 @@ PhysicalSize BackgroundImageGeometry::GetBackgroundObjectDimensions(
+ }
+ 
+ bool BackgroundImageGeometry::ShouldUseFixedAttachment(
+-    const FillLayer& fill_layer) const {
+-  // Only backgrounds fixed to viewport should be treated as fixed attachment.
+-  // See comments in the private constructor.
+-  return has_background_fixed_to_viewport_ &&
+-         // Solid color background should use default attachment.
+-         fill_layer.GetImage() &&
++    const FillLayer& fill_layer) {
++  // Solid color background should use default attachment.
++  return fill_layer.GetImage() &&
+          fill_layer.Attachment() == EFillAttachment::kFixed;
+ }
+ 
+ namespace {
+ 
+-PhysicalRect FixedAttachmentPositioningArea(const PaintInfo& paint_info,
+-                                            const LayoutBoxModelObject& obj) {
+-  DCHECK(obj.View());
+-  gfx::PointF viewport_origin_in_local_space =
+-      GeometryMapper::SourceToDestinationProjection(
+-          obj.View()->FirstFragment().LocalBorderBoxProperties().Transform(),
+-          paint_info.context.GetPaintController()
+-              .CurrentPaintChunkProperties()
+-              .Transform())
+-          .MapPoint(gfx::PointF());
+-  DCHECK(obj.GetFrameView());
+-  const ScrollableArea* layout_viewport = obj.GetFrameView()->LayoutViewport();
++PhysicalRect FixedAttachmentPositioningArea(
++    const LayoutBoxModelObject& obj,
++    const LayoutBoxModelObject* container) {
++  // TODO(crbug.com/667006): We should consider ancestor with transform as the
++  // fixed background container, instead of always the viewport.
++  const LocalFrameView* frame_view = obj.GetFrameView();
++  if (!frame_view)
++    return PhysicalRect();
++
++  const ScrollableArea* layout_viewport = frame_view->LayoutViewport();
+   DCHECK(layout_viewport);
+-  return PhysicalRect(
+-      PhysicalOffset::FromPointFRound(viewport_origin_in_local_space),
+-      PhysicalSize(layout_viewport->VisibleContentRect().size()));
++
++  PhysicalRect rect(PhysicalOffset(),
++                    PhysicalSize(layout_viewport->VisibleContentRect().size()));
++
++  if (const auto* layout_view = DynamicTo<LayoutView>(obj)) {
++    if (!(layout_view->GetBackgroundPaintLocation() &
++          kBackgroundPaintInContentsSpace))
++      return rect;
++    // The LayoutView is the only object that can paint a fixed background into
++    // its scrolling contents layer, so it gets a special adjustment here.
++    rect.offset = layout_view->ScrolledContentOffset();
++  }
++
++  rect.Move(AccumulatedScrollOffsetForFixedBackground(obj, container));
++
++  if (!container)
++    return rect;
++
++  rect.Move(
++      -container->LocalToAbsolutePoint(PhysicalOffset(), kIgnoreTransforms));
++
++  // By now we have converted the viewport rect to the border box space of
++  // |container|, however |container| does not necessarily create a paint
++  // offset translation node, thus its paint offset must be added to convert
++  // the rect to the space of the transform node.
++  // TODO(trchen): This function does only one simple thing -- mapping the
++  // viewport rect from frame space to whatever space the current paint
++  // context uses. However we can't always invoke geometry mapper because
++  // there are at least one caller uses this before PrePaint phase.
++  DCHECK_GE(container->GetDocument().Lifecycle().GetState(),
++            DocumentLifecycle::kPrePaintClean);
++  rect.Move(container->FirstFragment().PaintOffset());
++  return rect;
+ }
+ 
+ }  // Anonymous namespace
+@@ -346,10 +387,7 @@ PhysicalRect FixedAttachmentPositioningArea(const PaintInfo& paint_info,
+ BackgroundImageGeometry::BackgroundImageGeometry(
+     const LayoutView& view,
+     const PhysicalOffset& element_positioning_area_offset)
+-    : box_(&view), positioning_box_(&view.RootBox()) {
+-  has_background_fixed_to_viewport_ =
+-      view.StyleRef().HasFixedAttachmentBackgroundImage();
+-  painting_view_ = true;
++    : box_(&view), positioning_box_(&view.RootBox()), painting_view_(true) {
+   // The background of the box generated by the root element covers the
+   // entire canvas and will be painted by the view object, but the we should
+   // still use the root element box for positioning.
+@@ -360,17 +398,19 @@ BackgroundImageGeometry::BackgroundImageGeometry(
+ 
+ BackgroundImageGeometry::BackgroundImageGeometry(
+     const LayoutBoxModelObject& obj)
+-    : BackgroundImageGeometry(&obj, &obj) {}
++    : box_(&obj), positioning_box_(&obj) {
++  // Specialized constructor should be used for LayoutView.
++  DCHECK(!IsA<LayoutView>(obj));
++}
+ 
+ BackgroundImageGeometry::BackgroundImageGeometry(
+     const LayoutTableCell& cell,
+     const LayoutObject* background_object)
+-    : BackgroundImageGeometry(
+-          &cell,
+-          background_object && !background_object->IsTableCell()
+-              ? &To<LayoutBoxModelObject>(*background_object)
+-              : &cell) {
+-  painting_table_cell_ = true;
++    : box_(&cell),
++      positioning_box_(background_object && !background_object->IsTableCell()
++                           ? &To<LayoutBoxModelObject>(*background_object)
++                           : &cell),
++      painting_table_cell_(true) {
+   cell_using_container_background_ =
+       background_object && !background_object->IsTableCell();
+   if (cell_using_container_background_) {
+@@ -386,8 +426,7 @@ BackgroundImageGeometry::BackgroundImageGeometry(const LayoutNGTableCell& cell,
+                                                  PhysicalOffset cell_offset,
+                                                  const LayoutBox& table_part,
+                                                  PhysicalSize table_part_size)
+-    : BackgroundImageGeometry(&cell, &table_part) {
+-  painting_table_cell_ = true;
++    : box_(&cell), positioning_box_(&table_part), painting_table_cell_(true) {
+   cell_using_container_background_ = true;
+   element_positioning_area_offset_ = cell_offset;
+   positioning_size_override_ = table_part_size;
+@@ -395,10 +434,12 @@ BackgroundImageGeometry::BackgroundImageGeometry(const LayoutNGTableCell& cell,
+ 
+ BackgroundImageGeometry::BackgroundImageGeometry(
+     const NGPhysicalBoxFragment& fragment)
+-    : BackgroundImageGeometry(
+-          To<LayoutBoxModelObject>(fragment.GetLayoutObject()),
+-          To<LayoutBoxModelObject>(fragment.GetLayoutObject())) {
++    : box_(To<LayoutBoxModelObject>(fragment.GetLayoutObject())),
++      positioning_box_(box_) {
++  DCHECK(box_);
+   DCHECK(box_->IsBox());
++  // Specialized constructor should be used for LayoutView.
++  DCHECK(!IsA<LayoutView>(box_));
+ 
+   if (!fragment.IsOnlyForNode()) {
+     // The element is block-fragmented. We need to calculate the correct
+@@ -410,35 +451,6 @@ BackgroundImageGeometry::BackgroundImageGeometry(
+   }
+ }
+ 
+-BackgroundImageGeometry::BackgroundImageGeometry(
+-    const LayoutBoxModelObject* box,
+-    const LayoutBoxModelObject* positioning_box)
+-    : box_(box), positioning_box_(positioning_box) {
+-  // Specialized constructor should be used for LayoutView.
+-  DCHECK(!IsA<LayoutView>(box));
+-  DCHECK(box);
+-  DCHECK(positioning_box);
+-  if (positioning_box->StyleRef().HasFixedAttachmentBackgroundImage()) {
+-    has_background_fixed_to_viewport_ = true;
+-    // https://www.w3.org/TR/css-transforms-1/#transform-rendering
+-    // Fixed backgrounds on the root element are affected by any transform
+-    // specified for that element. For all other elements that are effected
+-    // by a transform, a value of fixed for the background-attachment property
+-    // is treated as if it had a value of scroll.
+-    for (const LayoutObject* container = box;
+-         container && !IsA<LayoutView>(container);
+-         container = container->Container()) {
+-      // Not using HasTransformRelatedProperty(), to excludes will-change:
+-      // transform, etc. Otherwise at least
+-      // compositing/backgrounds/fixed-backgrounds.html will fail.
+-      if (container->HasTransform()) {
+-        has_background_fixed_to_viewport_ = false;
+-        break;
+-      }
+-    }
+-  }
+-}
+-
+ void BackgroundImageGeometry::ComputeDestRectAdjustments(
+     const FillLayer& fill_layer,
+     const PhysicalRect& unsnapped_positioning_area,
+@@ -592,7 +604,8 @@ void BackgroundImageGeometry::ComputePositioningAreaAdjustments(
+ }
+ 
+ void BackgroundImageGeometry::ComputePositioningArea(
+-    const PaintInfo& paint_info,
++    const LayoutBoxModelObject* container,
++    PaintPhase paint_phase,
+     const FillLayer& fill_layer,
+     const PhysicalRect& paint_rect,
+     PhysicalRect& unsnapped_positioning_area,
+@@ -601,8 +614,9 @@ void BackgroundImageGeometry::ComputePositioningArea(
+     PhysicalOffset& snapped_box_offset) {
+   if (ShouldUseFixedAttachment(fill_layer)) {
+     // No snapping for fixed attachment.
++    SetHasNonLocalGeometry();
+     unsnapped_positioning_area =
+-        FixedAttachmentPositioningArea(paint_info, *box_);
++        FixedAttachmentPositioningArea(*box_, container);
+     unsnapped_dest_rect_ = snapped_dest_rect_ = snapped_positioning_area =
+         unsnapped_positioning_area;
+   } else {
+@@ -637,7 +651,7 @@ void BackgroundImageGeometry::ComputePositioningArea(
+     // * We are painting a block-fragmented box.
+     // * There is a border image, because it may not be opaque or may be outset.
+     bool disallow_border_derived_adjustment =
+-        !ShouldPaintSelfBlockBackground(paint_info.phase) ||
++        !ShouldPaintSelfBlockBackground(paint_phase) ||
+         fill_layer.Composite() != CompositeOperator::kCompositeSourceOver ||
+         painting_view_ || painting_table_cell_ || box_has_multiple_fragments_ ||
+         positioning_box_->StyleRef().BorderImage().GetImage() ||
+@@ -800,12 +814,10 @@ void BackgroundImageGeometry::CalculateFillTileSize(
+   return;
+ }
+ 
+-void BackgroundImageGeometry::Calculate(const PaintInfo& paint_info,
++void BackgroundImageGeometry::Calculate(const LayoutBoxModelObject* container,
++                                        PaintPhase paint_phase,
+                                         const FillLayer& fill_layer,
+                                         const PhysicalRect& paint_rect) {
+-  DCHECK_GE(box_->GetDocument().Lifecycle().GetState(),
+-            DocumentLifecycle::kPrePaintClean);
+-
+   // Unsnapped positioning area is used to derive quantities
+   // that reference source image maps and define non-integer values, such
+   // as phase and position.
+@@ -821,7 +833,7 @@ void BackgroundImageGeometry::Calculate(const PaintInfo& paint_info,
+   PhysicalOffset snapped_box_offset;
+ 
+   // This method also sets the destination rects.
+-  ComputePositioningArea(paint_info, fill_layer, paint_rect,
++  ComputePositioningArea(container, paint_phase, fill_layer, paint_rect,
+                          unsnapped_positioning_area, snapped_positioning_area,
+                          unsnapped_box_offset, snapped_box_offset);
+ 
+diff --git third_party/blink/renderer/core/paint/background_image_geometry.h third_party/blink/renderer/core/paint/background_image_geometry.h
+index 5bdd517d1aa1f..f1b44c82a4d22 100644
+--- third_party/blink/renderer/core/paint/background_image_geometry.h
++++ third_party/blink/renderer/core/paint/background_image_geometry.h
+@@ -23,7 +23,6 @@ class LayoutObject;
+ class LayoutTableCell;
+ class LayoutView;
+ class NGPhysicalBoxFragment;
+-struct PaintInfo;
+ 
+ class BackgroundImageGeometry {
+   STACK_ALLOCATED();
+@@ -40,7 +39,7 @@ class BackgroundImageGeometry {
+                           const LayoutObject* background_object);
+ 
+   // Generic constructor for all other elements.
+-  explicit BackgroundImageGeometry(const LayoutBoxModelObject&);
++  BackgroundImageGeometry(const LayoutBoxModelObject&);
+ 
+   // Constructor for TablesNG table parts.
+   BackgroundImageGeometry(const LayoutNGTableCell& cell,
+@@ -50,10 +49,8 @@ class BackgroundImageGeometry {
+ 
+   explicit BackgroundImageGeometry(const NGPhysicalBoxFragment&);
+ 
+-  // Calculates data members. This must be called before any of the following
+-  // getters is called. The document lifecycle phase must be at least
+-  // PrePaintClean.
+-  void Calculate(const PaintInfo& paint_info,
++  void Calculate(const LayoutBoxModelObject* container,
++                 PaintPhase,
+                  const FillLayer&,
+                  const PhysicalRect& paint_rect);
+ 
+@@ -89,6 +86,10 @@ class BackgroundImageGeometry {
+   // the image if used as a pattern with background-repeat: space.
+   const PhysicalSize& SpaceSize() const { return repeat_spacing_; }
+ 
++  // Has background-attachment: fixed. Implies that we can't always cheaply
++  // compute the destination rects.
++  bool HasNonLocalGeometry() const { return has_non_local_geometry_; }
++
+   // Whether the background needs to be positioned relative to a container
+   // element. Only used for tables.
+   bool CellUsingContainerBackground() const {
+@@ -101,10 +102,7 @@ class BackgroundImageGeometry {
+   InterpolationQuality ImageInterpolationQuality() const;
+ 
+  private:
+-  BackgroundImageGeometry(const LayoutBoxModelObject* box,
+-                          const LayoutBoxModelObject* positioning_box);
+-
+-  bool ShouldUseFixedAttachment(const FillLayer&) const;
++  static bool ShouldUseFixedAttachment(const FillLayer&);
+ 
+   void SetSpaceSize(const PhysicalSize& repeat_spacing) {
+     repeat_spacing_ = repeat_spacing;
+@@ -128,6 +126,7 @@ class BackgroundImageGeometry {
+   void SetSpaceY(LayoutUnit space, LayoutUnit extra_offset);
+ 
+   void UseFixedAttachment(const PhysicalOffset& attachment_point);
++  void SetHasNonLocalGeometry() { has_non_local_geometry_ = true; }
+   PhysicalOffset GetPositioningOffsetForCell(const LayoutTableCell&,
+                                              const LayoutBox&);
+   PhysicalSize GetBackgroundObjectDimensions(const LayoutTableCell&,
+@@ -152,7 +151,8 @@ class BackgroundImageGeometry {
+                                          LayoutRectOutsets&,
+                                          LayoutRectOutsets&) const;
+ 
+-  void ComputePositioningArea(const PaintInfo&,
++  void ComputePositioningArea(const LayoutBoxModelObject*,
++                              PaintPhase,
+                               const FillLayer&,
+                               const PhysicalRect&,
+                               PhysicalRect&,
+@@ -191,7 +191,7 @@ class BackgroundImageGeometry {
+   PhysicalOffset phase_;
+   PhysicalSize tile_size_;
+   PhysicalSize repeat_spacing_;
+-  bool has_background_fixed_to_viewport_ = false;
++  bool has_non_local_geometry_ = false;
+   bool painting_view_ = false;
+   bool painting_table_cell_ = false;
+   bool cell_using_container_background_ = false;
+diff --git third_party/blink/renderer/core/paint/box_painter_base.cc third_party/blink/renderer/core/paint/box_painter_base.cc
+index e13eb0b4ecc22..da3e56c7b2f98 100644
+--- third_party/blink/renderer/core/paint/box_painter_base.cc
++++ third_party/blink/renderer/core/paint/box_painter_base.cc
+@@ -955,7 +955,8 @@ void BoxPainterBase::PaintFillLayer(const PaintInfo& paint_info,
+   SkBlendMode composite_op = SkBlendMode::kSrcOver;
+   absl::optional<ScopedInterpolationQuality> interpolation_quality_context;
+   if (fill_layer_info.should_paint_image) {
+-    geometry.Calculate(paint_info, bg_layer, scrolled_paint_rect);
++    geometry.Calculate(paint_info.PaintContainer(), paint_info.phase, bg_layer,
++                       scrolled_paint_rect);
+     image = fill_layer_info.image->GetImage(
+         geometry.ImageClient(), geometry.ImageDocument(),
+         geometry.ImageStyle(style_), gfx::SizeF(geometry.TileSize()));
+diff --git third_party/blink/renderer/core/paint/paint_info.h third_party/blink/renderer/core/paint/paint_info.h
+index 290f1ec5ed9c1..45c81c2b0c45f 100644
+--- third_party/blink/renderer/core/paint/paint_info.h
++++ third_party/blink/renderer/core/paint/paint_info.h
+@@ -48,10 +48,12 @@ struct CORE_EXPORT PaintInfo {
+   PaintInfo(GraphicsContext& context,
+             const CullRect& cull_rect,
+             PaintPhase phase,
+-            PaintFlags paint_flags = PaintFlag::kNoFlag)
++            PaintFlags paint_flags = PaintFlag::kNoFlag,
++            const LayoutBoxModelObject* paint_container = nullptr)
+       : context(context),
+         phase(phase),
+         cull_rect_(cull_rect),
++        paint_container_(paint_container),
+         paint_flags_(paint_flags) {}
+ 
+   PaintInfo(GraphicsContext& new_context,
+@@ -59,6 +61,7 @@ struct CORE_EXPORT PaintInfo {
+       : context(new_context),
+         phase(copy_other_fields_from.phase),
+         cull_rect_(copy_other_fields_from.cull_rect_),
++        paint_container_(copy_other_fields_from.paint_container_),
+         fragment_id_(copy_other_fields_from.fragment_id_),
+         paint_flags_(copy_other_fields_from.paint_flags_) {
+     // We should never pass these flags to other PaintInfo.
+@@ -103,6 +106,10 @@ struct CORE_EXPORT PaintInfo {
+     return DisplayItem::PaintPhaseToClipType(phase);
+   }
+ 
++  const LayoutBoxModelObject* PaintContainer() const {
++    return paint_container_;
++  }
++
+   PaintFlags GetPaintFlags() const { return paint_flags_; }
+ 
+   const CullRect& GetCullRect() const { return cull_rect_; }
+@@ -188,6 +195,9 @@ struct CORE_EXPORT PaintInfo {
+  private:
+   CullRect cull_rect_;
+ 
++  // The box model object that originates the current painting.
++  const LayoutBoxModelObject* paint_container_;
++
+   // The ID of the fragment that we're currently painting.
+   //
+   // This is always used in legacy block fragmentation. In NG block
+diff --git third_party/blink/renderer/core/paint/paint_layer_painter.cc third_party/blink/renderer/core/paint/paint_layer_painter.cc
+index bf44e1a32d18e..47996cc127ebb 100644
+--- third_party/blink/renderer/core/paint/paint_layer_painter.cc
++++ third_party/blink/renderer/core/paint/paint_layer_painter.cc
+@@ -448,7 +448,8 @@ void PaintLayerPainter::PaintFragmentWithPhase(
+       context.GetPaintController(), chunk_properties, paint_layer_,
+       DisplayItem::PaintPhaseToDrawingType(phase));
+ 
+-  PaintInfo paint_info(context, cull_rect, phase, paint_flags);
++  PaintInfo paint_info(context, cull_rect, phase, paint_flags,
++      &paint_layer_.GetLayoutObject());
+   if (paint_layer_.GetLayoutObject().ChildPaintBlockedByDisplayLock())
+     paint_info.SetDescendantPaintingBlocked(true);
+ 
+diff --git third_party/blink/renderer/core/paint/svg_object_painter.cc third_party/blink/renderer/core/paint/svg_object_painter.cc
+index 7a943c600f663..8c8a9bc294269 100644
+--- third_party/blink/renderer/core/paint/svg_object_painter.cc
++++ third_party/blink/renderer/core/paint/svg_object_painter.cc
+@@ -37,7 +37,8 @@ void SVGObjectPainter::PaintResourceSubtree(GraphicsContext& context) {
+ 
+   PaintInfo info(
+       context, CullRect::Infinite(), PaintPhase::kForeground,
+-      PaintFlag::kOmitCompositingInfo | PaintFlag::kPaintingResourceSubtree);
++      PaintFlag::kOmitCompositingInfo | PaintFlag::kPaintingResourceSubtree,
++      &layout_object_.PaintingLayer()->GetLayoutObject());
+   layout_object_.Paint(info);
+ }
+ 
+diff --git third_party/blink/renderer/core/paint/view_painter_test.cc third_party/blink/renderer/core/paint/view_painter_test.cc
+index d5c26700ff773..a0da795a7d4db 100644
+--- third_party/blink/renderer/core/paint/view_painter_test.cc
++++ third_party/blink/renderer/core/paint/view_painter_test.cc
+@@ -9,7 +9,6 @@
+ #include "third_party/blink/renderer/core/paint/paint_controller_paint_test.h"
+ #include "third_party/blink/renderer/platform/graphics/paint/drawing_display_item.h"
+ #include "third_party/blink/renderer/platform/testing/paint_property_test_helpers.h"
+-#include "ui/gfx/geometry/skia_conversions.h"
+ 
+ using testing::ElementsAre;
+ 
+@@ -66,21 +65,20 @@ void ViewPainterFixedBackgroundTest::RunFixedBackgroundTest(
+ 
+   // This is the dest_rect_ calculated by BackgroundImageGeometry. For a fixed
+   // background in scrolling contents layer, its location is the scroll offset.
+-  auto rect = gfx::SkRectToRectF(static_cast<const cc::DrawRectOp*>(*it)->rect);
++  SkRect rect = static_cast<const cc::DrawRectOp*>(*it)->rect;
+   if (prefer_compositing_to_lcd_text) {
+-    EXPECT_EQ(gfx::RectF(0, 0, 800, 600), rect);
++    EXPECT_EQ(SkRect::MakeXYWH(0, 0, 800, 600), rect);
+   } else {
+-    EXPECT_EQ(gfx::RectF(scroll_offset.x(), scroll_offset.y(), 800, 600), rect);
++    EXPECT_EQ(SkRect::MakeXYWH(scroll_offset.x(), scroll_offset.y(), 800, 600),
++              rect);
+   }
+ }
+ 
+-TEST_P(ViewPainterFixedBackgroundTest,
+-       DocumentFixedBackgroundNotPreferCompositing) {
++TEST_P(ViewPainterFixedBackgroundTest, DocumentFixedBackgroundLowDPI) {
+   RunFixedBackgroundTest(false);
+ }
+ 
+-TEST_P(ViewPainterFixedBackgroundTest,
+-       DocumentFixedBackgroundPreferCompositing) {
++TEST_P(ViewPainterFixedBackgroundTest, DocumentFixedBackgroundHighDPI) {
+   RunFixedBackgroundTest(true);
+ }
+ 
+diff --git third_party/blink/web_tests/TestExpectations third_party/blink/web_tests/TestExpectations
+index 96eea2ede708a..91595433d14f1 100644
+--- third_party/blink/web_tests/TestExpectations
++++ third_party/blink/web_tests/TestExpectations
+@@ -824,6 +824,8 @@ crbug.com/1175040 external/wpt/css/css-backgrounds/background-repeat-space-5.html [ Failure ]
+ crbug.com/1175040 external/wpt/css/css-backgrounds/background-repeat-space-6.html [ Failure ]
+ crbug.com/1175040 external/wpt/css/css-backgrounds/background-repeat-space-7.html [ Failure ]
+ 
++crbug.com/667006 external/wpt/css/css-backgrounds/background-attachment-fixed-inside-transform-1.html [ Failure ]
++
+ # Bug accidentally masked by using square mask geometry.
+ crbug.com/1155161 svg/masking/mask-of-root.html [ Failure ]
+ 
+@@ -5808,6 +5810,11 @@ crbug.com/1199522 http/tests/devtools/layers/layers-3d-view-hit-testing.js [ Failure ]
+ # Failing css-transforms-2 web platform tests.
+ crbug.com/847356 external/wpt/css/css-transforms/transform-box/view-box-mutation-001.html [ Failure ]
+ 
++crbug.com/1261900 external/wpt/css/css-transforms/transform-fixed-bg-002.html [ Failure ]
++crbug.com/1261900 external/wpt/css/css-transforms/transform-fixed-bg-004.html [ Failure ]
++crbug.com/1261900 external/wpt/css/css-transforms/transform-fixed-bg-005.html [ Failure ]
++crbug.com/1261900 external/wpt/css/css-transforms/transform-fixed-bg-006.html [ Failure ]
++crbug.com/1261900 external/wpt/css/css-transforms/transform-fixed-bg-007.html [ Failure ]
+ # Started failing after rolling new version of check-layout-th.js
+ css3/flexbox/perpendicular-writing-modes-inside-flex-item.html [ Failure ]
+

--- a/patch/patches/revert_url.patch
+++ b/patch/patches/revert_url.patch
@@ -1,0 +1,66 @@
+diff --git net/base/schemeful_site.cc net/base/schemeful_site.cc
+index 51df09e13fc9f..419d634011bf9 100644
+--- net/base/schemeful_site.cc
++++ net/base/schemeful_site.cc
+@@ -38,6 +38,21 @@ SchemefulSite::ObtainASiteResult SchemefulSite::ObtainASite(
+   if (IsStandardSchemeWithNetworkHost(origin.scheme())) {
+     registerable_domain = GetDomainAndRegistry(
+         origin, net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
++
++    // For domains in which the eTLD+1 is not canonical, do not use the eTLD+1.
++    // This is for domains like foo.127.1, which has an eTLD+1 of 127.1, but
++    // https://127.1/ == https://127.0.0.1. This is intended as a temporary
++    // hack not to DCHECK for such origins, until the URL spec is updated to
++    // make such domains invalid in URLs.
++    // TODO(https://crbug.com/1157010): Remove once the fetch spec is updated,
++    // and GURL rejects such domains names.
++    url::CanonHostInfo host_info;
++    bool site_domain_is_safe =
++        registerable_domain.empty() || registerable_domain == origin.host() ||
++        registerable_domain ==
++            CanonicalizeHost(registerable_domain, &host_info);
++    if (!site_domain_is_safe)
++      registerable_domain.clear();
+   }
+ 
+   // If origin's host's registrable domain is null, then return (origin's
+diff --git url/url_canon_ip.cc url/url_canon_ip.cc
+index 1706377bd850a..7c3370a6328a6 100644
+--- url/url_canon_ip.cc
++++ url/url_canon_ip.cc
+@@ -165,7 +165,7 @@ CanonHostInfo::Family DoIPv4AddressToNumber(const CHAR* spec,
+       return CanonHostInfo::NEUTRAL;
+ 
+     if (family != CanonHostInfo::IPV4)
+-      return CanonHostInfo::BROKEN;
++      return CanonHostInfo::NEUTRAL;
+ 
+     ++existing_components;
+ 
+@@ -175,7 +175,7 @@ CanonHostInfo::Family DoIPv4AddressToNumber(const CHAR* spec,
+ 
+     // If there are more than 4 components, fail.
+     if (existing_components == 4)
+-      return CanonHostInfo::BROKEN;
++      return CanonHostInfo::NEUTRAL;
+ 
+     current_component_end = current_position - 1;
+     --current_position;
+@@ -187,7 +187,7 @@ CanonHostInfo::Family DoIPv4AddressToNumber(const CHAR* spec,
+   // within an 8-bit field.
+   for (int i = existing_components - 1; i > 0; i--) {
+     if (component_values[i] > std::numeric_limits<uint8_t>::max())
+-      return CanonHostInfo::BROKEN;
++      return CanonHostInfo::NEUTRAL;
+     address[existing_components - i - 1] =
+         static_cast<unsigned char>(component_values[i]);
+   }
+@@ -200,7 +200,7 @@ CanonHostInfo::Family DoIPv4AddressToNumber(const CHAR* spec,
+ 
+   // If the last component has residual bits, report overflow.
+   if (last_value != 0)
+-    return CanonHostInfo::BROKEN;
++    return CanonHostInfo::NEUTRAL;
+ 
+   // Tell the caller how many components we saw.
+   *num_ipv4_components = existing_components;

--- a/patch/patches/sec_headers.patch
+++ b/patch/patches/sec_headers.patch
@@ -1,0 +1,12 @@
+diff --git services/network/sec_header_helpers.cc services/network/sec_header_helpers.cc
+index 3710c6c6ed2b9..b0889bce43dee 100644
+--- services/network/sec_header_helpers.cc
++++ services/network/sec_header_helpers.cc
+@@ -167,6 +167,7 @@ void SetFetchMetadataHeaders(
+     const GURL* pending_redirect_url,
+     const mojom::URLLoaderFactoryParams& factory_params,
+     const cors::OriginAccessList& origin_access_list) {
++  return;
+   DCHECK(request);
+   DCHECK_NE(0u, request->url_chain().size());
+


### PR DESCRIPTION
### Goal of this PR
To have changes of our chromium fork as patch files. It should simplify the building.
It fixes the CHROMIUM_BUILD_COMPATIBILITY file as well and removes the libvpx_cve patch, as its not relevant for this CEF version.


### How is this PR achieving the goal



### This PR applies to the following area(s)
CEF


### Successfully tested on
The test projects provided by CEF, FiveM main menu

**Game builds:** N/A

**Platforms:** Windows


### Checklist
- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes. 

### Fixes issues
N/A


